### PR TITLE
docs: fix cargo doc warning and require local quality gates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,31 @@ Optional pre-pipeline **integer bilinear upscaling** (`chess_corners::upscale`, 
 | `par_pyramid` | facade, box-image-pyramid | SIMD/rayon in pyramid downsampling |
 | `cli` | facade | CLI-only deps (clap, anyhow, serde, tracing-subscriber) |
 
+## Pre-PR quality gates (mandatory)
+
+**Always run the full gate sequence below and fix every warning/error
+before opening or updating a pull request.** CI runs the same checks;
+local is faster and avoids noisy review cycles.
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --all-features
+cargo doc --workspace --no-deps --all-features
+mdbook build book
+```
+
+Notes:
+
+- `cargo doc` warnings (broken intra-doc links, missing docs on public
+  items, links to private items) are blocking — do not push with them.
+- Book rewrites should also be visually inspected: `mdbook serve book`.
+- Python bindings: `maturin develop -m crates/chess-corners-py/pyproject.toml`
+  plus `pytest crates/chess-corners-py/python_tests` when the Python
+  surface changes.
+- WASM: `wasm-pack build crates/chess-corners-wasm --target web` when
+  the JS-facing API changes.
+
 ## Key Design Constraints (from AGENTS.md)
 
 - **Determinism:** Same inputs → same outputs. Parallel results must be sorted by stable keys.

--- a/crates/chess-corners-core/src/descriptor.rs
+++ b/crates/chess-corners-core/src/descriptor.rs
@@ -87,8 +87,9 @@ pub struct CornerDescriptor {
     pub response: f32,
 
     /// Bright/dark amplitude (`|A|`, ≥ 0) recovered by the two-axis
-    /// tanh fit in [`fit_two_axes`]. Units are gray levels. Larger
-    /// means a stronger bright/dark separation at the ring radius.
+    /// tanh fit (see the `fit_two_axes` internal helper). Units are
+    /// gray levels. Larger means a stronger bright/dark separation at
+    /// the ring radius.
     /// This is an independent quantity from [`Self::response`] — they
     /// are computed by different estimators and must not be compared
     /// against each other or against the same threshold.


### PR DESCRIPTION
## Summary

- **Fix the `cargo doc --workspace --no-deps --all-features` warning**
  introduced by #37. `CornerDescriptor::contrast`'s doc-comment linked
  to the private `fit_two_axes` helper; rustdoc rejected the link
  because the target is `pub(crate)`. Replaced the intra-doc link with
  a plain code span so the reference remains but the warning
  disappears.

- **Add a `Pre-PR quality gates (mandatory)` section to `CLAUDE.md`**
  listing the exact commands agents should run before opening or
  updating a PR:

  ```bash
  cargo fmt --all --check
  cargo clippy --workspace --all-targets --all-features -- -D warnings
  cargo test --workspace --all-features
  cargo doc --workspace --no-deps --all-features
  mdbook build book
  ```

  `cargo doc` warnings are flagged as blocking. The note also points
  at the Python (`maturin develop` + `pytest`) and WASM
  (`wasm-pack build`) gates when the respective surfaces change. This
  is the kind of check that should have caught the #37 warning
  locally instead of landing on main.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo doc --workspace --no-deps --all-features` — no warnings
- [x] `cargo test --workspace --all-features` — green (run on parent
      branch before the cherry-pick; diff here touches only docs)