### PR TITLE
feat: expose Radon heatmap across facade, Python, and WASM

### DIFF
--- a/book/src/part-02-using-the-detector.md
+++ b/book/src/part-02-using-the-detector.md
@@ -323,6 +323,68 @@ precision on synthetic data.
 
 ---
 
+## 2.5 Radon heatmap (visualization)
+
+The whole-image Radon detector (`detector_mode = "radon"`) computes a
+dense `(max_α S_α − min_α S_α)²` response heatmap as an intermediate
+step. The heatmap is exposed across all wrappers for visualization,
+debugging, and downstream tooling — useful when tuning
+`ray_radius`, `image_upsample`, or the threshold floor.
+
+The heatmap is returned at *working resolution*: the input is
+optionally upscaled (`ChessConfig.upscale`) and then internally
+supersampled by the Radon detector (`radon_detector.image_upsample`,
+default 2). The working-to-input scale factor is therefore
+`upscale_factor * image_upsample`. Multiply input-pixel coordinates by
+this factor to land on heatmap pixels.
+
+Rust:
+
+```rust,no_run
+use chess_corners::{radon_heatmap_u8, ChessConfig};
+
+# fn run(img: &[u8], width: u32, height: u32) {
+let cfg = ChessConfig::radon();
+let map = radon_heatmap_u8(img, width, height, &cfg);
+println!("heatmap {}×{}, max = {:.1}",
+    map.width(), map.height(),
+    map.data().iter().copied().fold(f32::NEG_INFINITY, f32::max));
+# }
+```
+
+Python:
+
+```python
+import chess_corners
+import numpy as np
+
+cfg = chess_corners.ChessConfig.radon()
+heatmap = chess_corners.radon_heatmap(img, cfg)  # (H', W') float32
+print(heatmap.shape, heatmap.dtype, float(heatmap.max()))
+```
+
+WebAssembly (JS):
+
+```js
+import init, { ChessDetector } from 'chess-corners-wasm';
+
+await init();
+const det = new ChessDetector();
+det.set_detector_mode('radon');
+
+const heatmap = det.radon_heatmap(grayPixels, width, height);
+const w = det.radon_heatmap_width();
+const h = det.radon_heatmap_height();
+const scale = det.radon_heatmap_scale();  // working-to-input factor
+console.log('heatmap', w, 'x', h, 'scale', scale);
+```
+
+The heatmap is independent from corner detection: calling it does not
+require the detector mode to actually be `"radon"`, and it does not
+return corners.
+
+---
+
 In this part we focused on the public faces of the detector: the
 `image` helper, the raw buffer API, the CLI, and the Python bindings.
 In the next parts we will look under the hood at how the ChESS

--- a/crates/chess-corners-py/python/chess_corners/__init__.py
+++ b/crates/chess-corners-py/python/chess_corners/__init__.py
@@ -593,6 +593,28 @@ def find_chess_corners(image: Any, cfg: ChessConfig | None = None) -> Any:
     return _native.find_chess_corners(image, None if cfg is None else cfg.to_json())
 
 
+def radon_heatmap(image: Any, cfg: ChessConfig | None = None) -> Any:
+    """Compute the whole-image Radon detector heatmap.
+
+    Returns a 2D ``float32`` NumPy array at *working resolution* — that
+    is, ``height * upscale * radon_image_upsample`` rows by the same in
+    columns. The working-to-input scale factor is
+    ``cfg.upscale.factor * cfg.radon_detector.image_upsample`` (each
+    clamped to its supported range).
+
+    Parameters
+    ----------
+    image:
+        2D C-contiguous ``uint8`` NumPy array of shape ``(H, W)``.
+    cfg:
+        Optional :class:`ChessConfig`. The ``upscale`` and
+        ``radon_detector`` fields are honoured; other fields are
+        ignored because no corner detection is performed.
+    """
+
+    return _native.radon_heatmap(image, None if cfg is None else cfg.to_json())
+
+
 if hasattr(_native, "find_chess_corners_with_ml"):
     def find_chess_corners_with_ml(image: Any, cfg: ChessConfig | None = None) -> Any:
         """Detect chessboard corners using the ML-backed refiner pipeline."""
@@ -618,6 +640,7 @@ __all__ = [
     "SaddlePointConfig",
     "ThresholdMode",
     "find_chess_corners",
+    "radon_heatmap",
 ]
 
 if hasattr(_native, "find_chess_corners_with_ml"):

--- a/crates/chess-corners-py/python_tests/test_basic.py
+++ b/crates/chess-corners-py/python_tests/test_basic.py
@@ -75,3 +75,27 @@ def test_ml_refiner_api():
     assert corners.dtype == np.float32
     assert corners.ndim == 2
     assert corners.shape[1] == 9
+
+
+def test_radon_heatmap_shape_and_dtype():
+    img = _checkerboard(square_size=16, squares=8)
+    cfg = chess_corners.ChessConfig.radon()
+
+    heatmap = chess_corners.radon_heatmap(img, cfg)
+
+    upsample = max(1, min(2, cfg.radon_detector.image_upsample))
+    assert heatmap.dtype == np.float32
+    assert heatmap.shape == (img.shape[0] * upsample, img.shape[1] * upsample)
+    assert float(heatmap.max()) > 0.0
+    assert float(heatmap.min()) >= 0.0
+
+
+def test_radon_heatmap_default_config():
+    img = _checkerboard(square_size=16, squares=8)
+
+    heatmap = chess_corners.radon_heatmap(img)
+
+    assert heatmap.dtype == np.float32
+    assert heatmap.ndim == 2
+    assert heatmap.shape[0] >= img.shape[0]
+    assert heatmap.shape[1] >= img.shape[1]

--- a/crates/chess-corners-py/src/lib.rs
+++ b/crates/chess-corners-py/src/lib.rs
@@ -110,9 +110,35 @@ fn find_chess_corners_with_ml<'py>(
     corners_to_array(py, corners)
 }
 
+#[pyfunction(signature = (image, cfg_json=None))]
+fn radon_heatmap<'py>(
+    py: Python<'py>,
+    image: &Bound<'py, PyAny>,
+    cfg_json: Option<&str>,
+) -> PyResult<Py<PyAny>> {
+    let (array, height, width) = extract_image(image)?;
+    let view = array.as_array();
+    let slice = view.as_slice().ok_or_else(|| {
+        PyValueError::new_err("image must be a C-contiguous uint8 array of shape (H, W)")
+    })?;
+
+    let width_u32 =
+        u32::try_from(width).map_err(|_| PyValueError::new_err("image width exceeds u32::MAX"))?;
+    let height_u32 = u32::try_from(height)
+        .map_err(|_| PyValueError::new_err("image height exceeds u32::MAX"))?;
+
+    let cfg = resolve_cfg_json(cfg_json)?;
+    let map = chess_corners_rs::radon_heatmap_u8(slice, width_u32, height_u32, &cfg);
+
+    let arr = Array2::from_shape_vec((map.height(), map.width()), map.data().to_vec())
+        .map_err(|_| PyValueError::new_err("failed to build heatmap array"))?;
+    Ok(arr.into_pyarray(py).into_any().unbind())
+}
+
 #[pymodule(name = "_native")]
 fn native_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(find_chess_corners, m)?)?;
+    m.add_function(wrap_pyfunction!(radon_heatmap, m)?)?;
     #[cfg(feature = "ml-refiner")]
     {
         m.add_function(wrap_pyfunction!(find_chess_corners_with_ml, m)?)?;

--- a/crates/chess-corners-wasm/demo/app.js
+++ b/crates/chess-corners-wasm/demo/app.js
@@ -36,7 +36,7 @@ const nmsRadius = $('nmsRadius');
 const nmsRadiusVal = $('nmsRadiusVal');
 const minCluster = $('minCluster');
 const minClusterVal = $('minClusterVal');
-const broadMode = $('broadMode');
+const detectorMode = $('detectorMode');
 const pyrLevels = $('pyrLevels');
 const pyrLevelsVal = $('pyrLevelsVal');
 const pyrMinSize = $('pyrMinSize');
@@ -44,6 +44,7 @@ const pyrMinSizeVal = $('pyrMinSizeVal');
 const upscaleFactor = $('upscaleFactor');
 const refiner = $('refiner');
 const autoRun = $('autoRun');
+const showHeatmap = $('showHeatmap');
 const showAxes = $('showAxes');
 const arrowLen = $('arrowLen');
 const arrowLenVal = $('arrowLenVal');
@@ -83,11 +84,48 @@ function configureDetector(det) {
   det.set_threshold(parseFloat(threshold.value));
   det.set_nms_radius(parseInt(nmsRadius.value, 10));
   det.set_min_cluster_size(parseInt(minCluster.value, 10));
-  det.set_broad_mode(broadMode.checked);
+  det.set_detector_mode(detectorMode.value);
   det.set_pyramid_levels(parseInt(pyrLevels.value, 10));
   det.set_pyramid_min_size(parseInt(pyrMinSize.value, 10));
   det.set_upscale_factor(parseInt(upscaleFactor.value, 10));
   det.set_refiner(refiner.value);
+}
+
+// Render a working-resolution Radon heatmap into the main canvas at
+// input-image dimensions. The detector exposes the heatmap at
+// (width * upscale * radon_image_upsample) — we downsample by
+// `radon_heatmap_scale()` so the overlay aligns with corner overlays in
+// input pixel space.
+function drawHeatmap(heatmap, hmW, hmH, scale) {
+  // Find max for normalization.
+  let maxV = 0;
+  for (let i = 0; i < heatmap.length; i++) {
+    if (heatmap[i] > maxV) maxV = heatmap[i];
+  }
+  if (maxV <= 0) maxV = 1;
+
+  // Render the heatmap directly at its working resolution onto an
+  // offscreen canvas, then drawImage with downscaling so the result
+  // matches input dimensions.
+  const off = document.createElement('canvas');
+  off.width = hmW;
+  off.height = hmH;
+  const offCtx = off.getContext('2d');
+  const img = offCtx.createImageData(hmW, hmH);
+  const inv = 255 / maxV;
+  for (let i = 0, j = 0; i < heatmap.length; i++, j += 4) {
+    const v = Math.min(255, Math.max(0, heatmap[i] * inv));
+    img.data[j] = v;
+    img.data[j + 1] = v;
+    img.data[j + 2] = v;
+    img.data[j + 3] = 255;
+  }
+  offCtx.putImageData(img, 0, 0);
+
+  // The heatmap is at input * scale; draw it scaled to currentW × currentH.
+  ctx.imageSmoothingEnabled = false;
+  ctx.drawImage(off, 0, 0, hmW, hmH, 0, 0, currentW, currentH);
+  ctx.imageSmoothingEnabled = true;
 }
 
 function drawImage(bitmap) {
@@ -175,15 +213,34 @@ function run() {
   lastCorners = result;
   const n = result.length / STRIDE;
 
-  // Redraw image + overlay.
-  ctx.putImageData(new ImageData(currentRGBA, currentW, currentH), 0, 0);
+  // Background: original image, unless heatmap overlay is requested.
+  let heatmapMs = 0;
+  if (showHeatmap.checked) {
+    const h0 = performance.now();
+    const heatmap = detector.radon_heatmap_rgba(currentRGBA, currentW, currentH);
+    const hmW = detector.radon_heatmap_width();
+    const hmH = detector.radon_heatmap_height();
+    const scale = detector.radon_heatmap_scale();
+    heatmapMs = performance.now() - h0;
+    // Black backdrop in case the heatmap dims fail to fully cover the canvas.
+    canvas.width = currentW;
+    canvas.height = currentH;
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, currentW, currentH);
+    drawHeatmap(heatmap, hmW, hmH, scale);
+  } else {
+    ctx.putImageData(new ImageData(currentRGBA, currentW, currentH), 0, 0);
+  }
   drawCorners(result);
 
-  statsEl.textContent =
+  const baseStats =
     `corners: ${n}\n` +
     `detect:  ${(t1 - t0).toFixed(1)} ms\n` +
     `size:    ${currentW}×${currentH}\n` +
     `upscale: ${upscaleFactor.value === '0' ? 'off' : upscaleFactor.value + '×'}`;
+  statsEl.textContent = showHeatmap.checked
+    ? `${baseStats}\nheatmap: ${heatmapMs.toFixed(1)} ms`
+    : baseStats;
   setStatus(cameraStream ? 'webcam live' : 'ok');
 }
 
@@ -195,9 +252,9 @@ function scheduleRun() {
 
 function setupAutoRerun() {
   const triggers = [
-    threshold, nmsRadius, minCluster, broadMode,
+    threshold, nmsRadius, minCluster, detectorMode,
     pyrLevels, pyrMinSize, upscaleFactor, refiner,
-    showAxes, arrowLen, dotRadius,
+    showHeatmap, showAxes, arrowLen, dotRadius,
   ];
   for (const el of triggers) {
     el.addEventListener('change', scheduleRun);

--- a/crates/chess-corners-wasm/demo/index.html
+++ b/crates/chess-corners-wasm/demo/index.html
@@ -281,6 +281,14 @@
       <div class="panel">
         <h2>Detector</h2>
         <label>
+          <span class="lbl">Mode</span>
+          <select id="detectorMode">
+            <option value="canonical" selected>canonical (ChESS r=5)</option>
+            <option value="broad">broad (ChESS r=10)</option>
+            <option value="radon">radon (whole-image)</option>
+          </select>
+        </label>
+        <label>
           <span class="lbl">Threshold</span>
           <input type="range" id="threshold" min="0" max="0.8" step="0.01" value="0.20">
           <span class="val" id="thresholdVal">0.20</span>
@@ -294,10 +302,6 @@
           <span class="lbl">Min cluster</span>
           <input type="range" id="minCluster" min="1" max="8" step="1" value="2">
           <span class="val" id="minClusterVal">2</span>
-        </label>
-        <label>
-          <span class="lbl">Broad ring (r=10)</span>
-          <input type="checkbox" id="broadMode">
         </label>
       </div>
 
@@ -347,6 +351,10 @@
 
       <div class="panel">
         <h2>Overlay</h2>
+        <label>
+          <span class="lbl">Radon heatmap</span>
+          <input type="checkbox" id="showHeatmap">
+        </label>
         <label>
           <span class="lbl">Show axes</span>
           <input type="checkbox" id="showAxes" checked>

--- a/crates/chess-corners-wasm/src/lib.rs
+++ b/crates/chess-corners-wasm/src/lib.rs
@@ -30,6 +30,14 @@ pub struct ChessDetector {
     buffers: PyramidBuffers,
     last_response: Option<ResponseMap>,
     last_radon_response: Option<ResponseMap>,
+    /// Working-to-input scale factor cached at the moment
+    /// `radon_heatmap` produced `last_radon_response`. Returning a
+    /// cached value (instead of recomputing from the live config)
+    /// keeps `radon_heatmap_width` / `_height` / `_scale` mutually
+    /// consistent if the caller mutates the detector's upscale or
+    /// `radon_detector.image_upsample` between the heatmap call and
+    /// the accessor calls. `0` until the first heatmap is computed.
+    last_radon_scale: u32,
 }
 
 impl Default for ChessDetector {
@@ -48,6 +56,7 @@ impl ChessDetector {
             buffers: PyramidBuffers::with_capacity(1),
             last_response: None,
             last_radon_response: None,
+            last_radon_scale: 0,
         }
     }
 
@@ -60,6 +69,7 @@ impl ChessDetector {
             buffers: PyramidBuffers::with_capacity(levels),
             last_response: None,
             last_radon_response: None,
+            last_radon_scale: 0,
         }
     }
 
@@ -239,6 +249,13 @@ impl ChessDetector {
         let resp = radon_heatmap_u8(pixels, width, height, &self.config);
         let arr = js_sys::Float32Array::new_with_length(resp.data().len() as u32);
         arr.copy_from(resp.data());
+        // Cache the scale alongside the response so the three
+        // accessors (width / height / scale) stay mutually consistent
+        // even if the caller mutates `set_upscale_factor` /
+        // `radon_detector.image_upsample` after this call.
+        let upscale = self.config.upscale.effective_factor().max(1);
+        let radon_up = self.config.radon_detector.image_upsample.clamp(1, 2);
+        self.last_radon_scale = upscale * radon_up;
         self.last_radon_response = Some(resp);
         arr
     }
@@ -274,12 +291,15 @@ impl ChessDetector {
     /// Multiply input-pixel coordinates by this factor to land on the
     /// corresponding heatmap pixel; divide heatmap-pixel coordinates by
     /// it to recover input pixels. Equals
-    /// `upscale_factor * radon_detector.image_upsample` (clamped to the
-    /// supported range).
+    /// `upscale_factor * radon_detector.image_upsample` (clamped to
+    /// the supported range) **as it was at the time of the last
+    /// `radon_heatmap` call** — mutating the detector's upscale or
+    /// `radon_detector.image_upsample` afterwards does not change
+    /// this value, so the trio of width / height / scale stays
+    /// consistent for overlay alignment. Returns `0` if no heatmap
+    /// has been computed yet.
     pub fn radon_heatmap_scale(&self) -> u32 {
-        let upscale = self.config.upscale.effective_factor().max(1);
-        let radon_up = self.config.radon_detector.image_upsample.clamp(1, 2);
-        upscale * radon_up
+        self.last_radon_scale
     }
 }
 

--- a/crates/chess-corners-wasm/src/lib.rs
+++ b/crates/chess-corners-wasm/src/lib.rs
@@ -1,5 +1,6 @@
 use chess_corners::{
-    ChessConfig, DetectorMode, PyramidBuffers, RefinementMethod, ThresholdMode, UpscaleConfig,
+    radon_heatmap_u8, ChessConfig, DetectorMode, PyramidBuffers, RefinementMethod, ThresholdMode,
+    UpscaleConfig,
 };
 use chess_corners_core::response::chess_response_u8;
 use chess_corners_core::ResponseMap;
@@ -28,6 +29,7 @@ pub struct ChessDetector {
     config: ChessConfig,
     buffers: PyramidBuffers,
     last_response: Option<ResponseMap>,
+    last_radon_response: Option<ResponseMap>,
 }
 
 impl Default for ChessDetector {
@@ -45,6 +47,7 @@ impl ChessDetector {
             config: ChessConfig::single_scale(),
             buffers: PyramidBuffers::with_capacity(1),
             last_response: None,
+            last_radon_response: None,
         }
     }
 
@@ -56,6 +59,7 @@ impl ChessDetector {
             config,
             buffers: PyramidBuffers::with_capacity(levels),
             last_response: None,
+            last_radon_response: None,
         }
     }
 
@@ -208,6 +212,74 @@ impl ChessDetector {
     /// Height of the last computed response map.
     pub fn response_height(&self) -> u32 {
         self.last_response.as_ref().map_or(0, |r| r.height() as u32)
+    }
+
+    // ---- Radon heatmap ----
+
+    /// Compute the whole-image Radon detector heatmap from grayscale
+    /// pixels.
+    ///
+    /// Returns the dense `(max_α S_α − min_α S_α)²` Radon response as a
+    /// row-major `Float32Array` at *working resolution* — that is,
+    /// `width * upscale * radon_image_upsample` by the same in `y`.
+    /// Use [`Self::radon_heatmap_width`] / [`Self::radon_heatmap_height`]
+    /// to get the actual dimensions, and [`Self::radon_heatmap_scale`]
+    /// for the working-to-input scale factor.
+    ///
+    /// Honours `set_upscale_factor`, `set_threshold` (via
+    /// `radon_detector.threshold_*`), and other Radon tuning state on
+    /// the detector. The detector mode does not need to be set to
+    /// `"radon"` to call this — the heatmap is always computable.
+    pub fn radon_heatmap(
+        &mut self,
+        pixels: &[u8],
+        width: u32,
+        height: u32,
+    ) -> js_sys::Float32Array {
+        let resp = radon_heatmap_u8(pixels, width, height, &self.config);
+        let arr = js_sys::Float32Array::new_with_length(resp.data().len() as u32);
+        arr.copy_from(resp.data());
+        self.last_radon_response = Some(resp);
+        arr
+    }
+
+    /// Compute the Radon heatmap from RGBA pixels (e.g. from canvas
+    /// `getImageData`). Converts to grayscale internally.
+    pub fn radon_heatmap_rgba(
+        &mut self,
+        pixels: &[u8],
+        width: u32,
+        height: u32,
+    ) -> js_sys::Float32Array {
+        let gray = rgba_to_gray(pixels, width, height);
+        self.radon_heatmap(&gray, width, height)
+    }
+
+    /// Width of the last computed Radon heatmap (working resolution).
+    pub fn radon_heatmap_width(&self) -> u32 {
+        self.last_radon_response
+            .as_ref()
+            .map_or(0, |r| r.width() as u32)
+    }
+
+    /// Height of the last computed Radon heatmap (working resolution).
+    pub fn radon_heatmap_height(&self) -> u32 {
+        self.last_radon_response
+            .as_ref()
+            .map_or(0, |r| r.height() as u32)
+    }
+
+    /// Working-to-input scale factor for the last computed Radon heatmap.
+    ///
+    /// Multiply input-pixel coordinates by this factor to land on the
+    /// corresponding heatmap pixel; divide heatmap-pixel coordinates by
+    /// it to recover input pixels. Equals
+    /// `upscale_factor * radon_detector.image_upsample` (clamped to the
+    /// supported range).
+    pub fn radon_heatmap_scale(&self) -> u32 {
+        let upscale = self.config.upscale.effective_factor().max(1);
+        let radon_up = self.config.radon_detector.image_upsample.clamp(1, 2);
+        upscale * radon_up
     }
 }
 

--- a/crates/chess-corners/src/lib.rs
+++ b/crates/chess-corners/src/lib.rs
@@ -155,6 +155,7 @@ mod config;
 #[cfg(feature = "ml-refiner")]
 mod ml_refiner;
 mod multiscale;
+pub mod radon;
 pub mod upscale;
 
 // Re-export a focused subset of core types for convenience. Consumers that
@@ -186,6 +187,11 @@ pub use crate::multiscale::{
 #[cfg(feature = "ml-refiner")]
 pub use crate::multiscale::{find_chess_corners_buff_with_ml, find_chess_corners_with_ml};
 pub use box_image_pyramid::{ImageBuffer, PyramidBuffers, PyramidParams};
+
+// Radon-detector convenience entry points.
+#[cfg(feature = "image")]
+pub use crate::radon::radon_heatmap_image;
+pub use crate::radon::radon_heatmap_u8;
 
 /// Detect chessboard corners from a raw grayscale image buffer.
 ///

--- a/crates/chess-corners/src/radon.rs
+++ b/crates/chess-corners/src/radon.rs
@@ -1,0 +1,164 @@
+//! Public Radon-detector convenience functions.
+//!
+//! The whole-image Duda-Frese Radon detector lives in
+//! [`chess_corners_core::radon_detector`]; the corner-detection path is
+//! exposed via [`crate::find_chess_corners_u8`] when
+//! [`ChessConfig::detector_mode`](crate::ChessConfig::detector_mode) is
+//! [`DetectorMode::Radon`](crate::DetectorMode::Radon). This module
+//! adds a thin wrapper that returns the dense Radon response heatmap
+//! (the intermediate `(max_α S_α − min_α S_α)²` image) for
+//! visualization and debugging.
+//!
+//! The heatmap is returned at *working resolution* — that is,
+//! `width * upscale_factor * radon_image_upsample` by the same in `y`.
+//! Use [`ResponseMap::width`] / [`ResponseMap::height`] for the actual
+//! dimensions; the working-to-input scale factor is
+//! `cfg.upscale.effective_factor() *
+//! cfg.radon_detector.image_upsample.clamp(1, 2)`.
+
+use chess_corners_core::{radon_response_u8, ImageView, RadonBuffers, ResponseMap};
+
+use crate::config::ChessConfig;
+use crate::upscale::{self, UpscaleBuffers};
+
+/// Compute the whole-image Radon response heatmap from a raw
+/// grayscale buffer.
+///
+/// `img` must be `width * height` bytes in row-major order. If
+/// `cfg.upscale` is enabled, the input is upscaled first (same path as
+/// [`crate::find_chess_corners_u8`]) and the heatmap is returned at the
+/// working resolution of the upscaled + radon-supersampled image.
+///
+/// The heatmap data is row-major `f32`, length
+/// `map.width() * map.height()`. Values are non-negative.
+///
+/// # Panics
+///
+/// Panics if `img.len() != width * height` or if the upscale
+/// configuration fails validation.
+#[must_use]
+pub fn radon_heatmap_u8(img: &[u8], width: u32, height: u32, cfg: &ChessConfig) -> ResponseMap {
+    cfg.upscale
+        .validate()
+        .expect("invalid upscale configuration");
+
+    let src_w = width as usize;
+    let src_h = height as usize;
+    let view = ImageView::from_u8_slice(src_w, src_h, img)
+        .expect("image dimensions must match buffer length");
+
+    let factor = cfg.upscale.effective_factor();
+    let mut rb = RadonBuffers::new();
+
+    if factor <= 1 {
+        let resp = radon_response_u8(
+            view.data,
+            view.width,
+            view.height,
+            &cfg.radon_detector,
+            &mut rb,
+        );
+        return resp.to_response_map();
+    }
+
+    let mut up_buffers = UpscaleBuffers::new();
+    let upscaled = upscale::upscale_bilinear_u8(img, src_w, src_h, factor, &mut up_buffers)
+        .expect("invalid upscale configuration");
+    let resp = radon_response_u8(
+        upscaled.data,
+        upscaled.width,
+        upscaled.height,
+        &cfg.radon_detector,
+        &mut rb,
+    );
+    resp.to_response_map()
+}
+
+/// Compute the Radon response heatmap from an `image::GrayImage`.
+///
+/// Convenience wrapper over [`radon_heatmap_u8`] when the `image`
+/// feature is enabled.
+#[cfg(feature = "image")]
+#[must_use]
+pub fn radon_heatmap_image(img: &::image::GrayImage, cfg: &ChessConfig) -> ResponseMap {
+    let (w, h) = img.dimensions();
+    radon_heatmap_u8(img.as_raw(), w, h, cfg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ChessConfig;
+    use chess_corners_core::{radon_response_u8 as core_radon, RadonBuffers as CoreRadonBuffers};
+
+    fn synthetic_board(w: usize, h: usize) -> Vec<u8> {
+        // 8×8 alternating-square board scaled to (w, h). Generates real
+        // saddle structure so the Radon response is not all zeros.
+        let cell = (w.min(h) / 9).max(2);
+        let mut out = vec![0u8; w * h];
+        for y in 0..h {
+            for x in 0..w {
+                let cx = x / cell;
+                let cy = y / cell;
+                out[y * w + x] = if (cx + cy) & 1 == 0 { 220 } else { 35 };
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn heatmap_matches_core_path_no_upscale() {
+        let (w, h) = (96usize, 72usize);
+        let img = synthetic_board(w, h);
+        let cfg = ChessConfig::radon();
+
+        let map = radon_heatmap_u8(&img, w as u32, h as u32, &cfg);
+
+        let mut rb = CoreRadonBuffers::new();
+        let view = core_radon(&img, w, h, &cfg.radon_detector, &mut rb);
+        assert_eq!(map.width(), view.width());
+        assert_eq!(map.height(), view.height());
+        assert_eq!(map.data().len(), view.data().len());
+        // Bitwise-identical: the facade just copies the borrowed slice.
+        assert_eq!(map.data(), view.data());
+    }
+
+    #[test]
+    fn heatmap_dimensions_match_working_resolution() {
+        let (w, h) = (96usize, 72usize);
+        let img = synthetic_board(w, h);
+        let cfg = ChessConfig::radon();
+        let upsample = cfg.radon_detector.image_upsample.clamp(1, 2) as usize;
+
+        let map = radon_heatmap_u8(&img, w as u32, h as u32, &cfg);
+        assert_eq!(map.width(), w * upsample);
+        assert_eq!(map.height(), h * upsample);
+    }
+
+    #[test]
+    fn heatmap_is_non_zero_on_a_board() {
+        let (w, h) = (96usize, 72usize);
+        let img = synthetic_board(w, h);
+        let cfg = ChessConfig::radon();
+
+        let map = radon_heatmap_u8(&img, w as u32, h as u32, &cfg);
+        let max = map.data().iter().copied().fold(f32::NEG_INFINITY, f32::max);
+        assert!(max > 0.0, "expected positive Radon response on a board");
+    }
+
+    #[test]
+    fn heatmap_honors_upscale_factor() {
+        use crate::upscale::UpscaleConfig;
+
+        let (w, h) = (48usize, 36usize);
+        let img = synthetic_board(w, h);
+        let mut cfg = ChessConfig::radon();
+        cfg.upscale = UpscaleConfig::fixed(2);
+        let radon_upsample = cfg.radon_detector.image_upsample.clamp(1, 2) as usize;
+
+        let map = radon_heatmap_u8(&img, w as u32, h as u32, &cfg);
+        // Working resolution = input × upscale × radon_image_upsample.
+        assert_eq!(map.width(), w * 2 * radon_upsample);
+        assert_eq!(map.height(), h * 2 * radon_upsample);
+    }
+}


### PR DESCRIPTION
## Summary

- Expose the dense Radon-detector response heatmap as a first-class public API on every layer (facade / Python / WASM), so visualization and debugging tools can read the intermediate `(max_α S_α − min_α S_α)²` image without re-running corner detection.
- Heatmap is returned at *working resolution* (`width * upscale * radon_image_upsample`); each wrapper surfaces the working-to-input scale factor so callers can align overlays.
- Demo gains a "Radon heatmap" overlay toggle and a "Detector mode" selector (canonical/broad/radon) that replaces the old broad-only checkbox.

## What's new

| Layer | API |
|---|---|
| `chess-corners` | `radon_heatmap_u8(image, w, h, &cfg) -> ResponseMap`, plus `radon_heatmap_image` under `feature = "image"` |
| `chess-corners-py` | `chess_corners.radon_heatmap(image, cfg=None) -> np.ndarray[float32]` shaped `(H', W')` |
| `chess-corners-wasm` | `ChessDetector::{radon_heatmap, radon_heatmap_rgba, radon_heatmap_width, radon_heatmap_height, radon_heatmap_scale}` mirroring the existing ChESS `response()` pattern |
| Demo | "Detector mode" select + "Radon heatmap" toggle |
| Book | New §2.5 with Rust / Python / JS examples |

## Test plan

- [x] `cargo test -p chess-corners --lib radon::` — 4 new unit tests (heatmap matches core path, working-resolution dimensions, non-zero on a board, upscale factor honoured)
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] `cargo doc --workspace --no-deps --all-features` (warning-free)
- [x] `mdbook build book`
- [x] `pytest crates/chess-corners-py/python_tests` (12/12 incl. 2 new heatmap tests)
- [x] `wasm-pack build crates/chess-corners-wasm --target web`
- [ ] Manually open the demo in a browser, switch detector mode to "radon", toggle the heatmap, confirm the visualization aligns with detected corners

🤖 Generated with [Claude Code](https://claude.com/claude-code)