### PR TITLE
chore: rename npm package to @vitavision/chess-corners

### DIFF
--- a/.github/workflows/release-npm-deprecate.yml
+++ b/.github/workflows/release-npm-deprecate.yml
@@ -1,0 +1,96 @@
+name: Deprecate legacy npm package (chess-corners-wasm)
+
+# One-shot, manually-triggered workflow that publishes a final
+# tombstone version of the legacy `chess-corners-wasm` npm package and
+# marks it deprecated, redirecting users to `@vitavision/chess-corners`.
+#
+# Run this once after the first `@vitavision/chess-corners` release has
+# landed on npm. The workflow is idempotent against the
+# `npm deprecate` step but `npm publish` will refuse to overwrite an
+# already-published version, so bump `tombstone_version` if you re-run.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tombstone_version:
+        description: "Final version to publish under the old name (e.g. 0.6.99)."
+        required: true
+        default: "0.6.99"
+
+jobs:
+  deprecate-legacy:
+    name: Publish tombstone & deprecate
+    runs-on: ubuntu-latest
+
+    environment: npm
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build WASM package (artifact reused for tombstone)
+        run: wasm-pack build crates/chess-corners-wasm --target web --release
+
+      - name: Patch package.json (legacy name + tombstone version)
+        shell: bash
+        env:
+          TOMBSTONE: ${{ inputs.tombstone_version }}
+        run: |
+          PKG=crates/chess-corners-wasm/pkg/package.json
+          jq --arg v "$TOMBSTONE" \
+            '.name = "chess-corners-wasm" | .version = $v' \
+            "$PKG" > "$PKG.tmp"
+          mv "$PKG.tmp" "$PKG"
+          jq . "$PKG"
+
+      - name: Write MOVED README
+        shell: bash
+        env:
+          TOMBSTONE: ${{ inputs.tombstone_version }}
+        run: |
+          cat > crates/chess-corners-wasm/pkg/README.md <<EOF
+          # chess-corners-wasm — moved
+
+          This package has been renamed to **\`@vitavision/chess-corners\`**.
+
+          Install:
+
+          \`\`\`bash
+          npm install @vitavision/chess-corners
+          \`\`\`
+
+          The latest \`chess-corners-wasm\` release is the tombstone version
+          \`$TOMBSTONE\`. No further functional updates will be published under
+          this name.
+
+          See [the project README](https://github.com/VitalyVorobyev/chess-corners-rs)
+          for migration details.
+          EOF
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish tombstone version
+        working-directory: crates/chess-corners-wasm/pkg
+        # Trusted publishing via GitHub OIDC; no long-lived npm token required.
+        run: npm publish --access public
+
+      - name: Mark all chess-corners-wasm versions deprecated
+        shell: bash
+        env:
+          TOMBSTONE: ${{ inputs.tombstone_version }}
+        run: |
+          npm deprecate "chess-corners-wasm@<=$TOMBSTONE" \
+            "Renamed to @vitavision/chess-corners. Run: npm install @vitavision/chess-corners"

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -40,6 +40,21 @@ jobs:
       - name: Build WASM package
         run: wasm-pack build crates/chess-corners-wasm --target web --release
 
+      - name: Rename npm package to @vitavision/chess-corners
+        # `wasm-pack` derives the npm package name from the Rust crate
+        # name (`chess-corners-wasm`). We publish under the scoped name
+        # `@vitavision/chess-corners` instead — see CHANGELOG 0.7.0 for
+        # the rebrand note. The crate-derived JS file basename
+        # (`chess_corners_wasm.js`) stays intact, so consumers always
+        # `import` from the package name; the inner module path is
+        # an implementation detail.
+        shell: bash
+        run: |
+          PKG=crates/chess-corners-wasm/pkg/package.json
+          jq '.name = "@vitavision/chess-corners"' "$PKG" > "$PKG.tmp"
+          mv "$PKG.tmp" "$PKG"
+          test "$(jq -r .name "$PKG")" = "@vitavision/chess-corners"
+
       - name: Copy README into pkg
         run: cp crates/chess-corners-wasm/README.md crates/chess-corners-wasm/pkg/README.md
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **npm package renamed to `@vitavision/chess-corners`.** The
+  WebAssembly bindings (Rust crate `chess-corners-wasm`, npm artifact
+  formerly published as `chess-corners-wasm`) now publish under the
+  scoped name `@vitavision/chess-corners`. The Rust crate name is
+  unchanged; only the npm package name moves. The legacy
+  `chess-corners-wasm` package is being deprecated on npm via a
+  one-shot tombstone release that points users at the new name. The
+  exported JS API is identical — migrate by replacing the dependency
+  name in `package.json` / your `import` statements.
+
 ### Added
 
 - **`DetectorMode::Radon`** — the whole-image Duda-Frese Radon

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Six crates with strict layering (see AGENTS.md for full rules):
 
 ```
 chess-corners-py    (PyO3 bindings, module name: chess_corners)
-chess-corners-wasm  (wasm-bindgen bindings, npm package: chess-corners-wasm)
+chess-corners-wasm  (wasm-bindgen bindings, npm package: @vitavision/chess-corners)
        ↓
 chess-corners       (High-level facade, multiscale pipeline, CLI)
        ↓

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It also ships:
 
 - a CLI binary
 - a Python package (`chess_corners`)
-- a WebAssembly package (`chess-corners-wasm`) for browser usage
+- a WebAssembly package (npm: `@vitavision/chess-corners`) for browser usage
 - an optional ML-backed refinement path
 
 ## Diligence statement
@@ -140,16 +140,24 @@ Every public Python config object supports:
 ## JavaScript / WebAssembly
 
 The `chess-corners-wasm` crate provides browser-ready bindings via `wasm-bindgen`.
-Build with [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/):
+The published npm package is **`@vitavision/chess-corners`** (renamed from
+the unscoped `chess-corners-wasm` in 0.7.0; the legacy package is deprecated
+on npm). Build locally with [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/):
 
 ```bash
 wasm-pack build crates/chess-corners-wasm --target web
 ```
 
+Or install from npm:
+
+```bash
+npm install @vitavision/chess-corners
+```
+
 Use in a web app:
 
 ```js
-import init, { ChessDetector } from 'chess-corners-wasm';
+import init, { ChessDetector } from '@vitavision/chess-corners';
 
 await init();
 const detector = new ChessDetector();

--- a/crates/chess-corners-wasm/README.md
+++ b/crates/chess-corners-wasm/README.md
@@ -1,8 +1,19 @@
-# chess-corners-wasm
+# @vitavision/chess-corners
 
 WebAssembly bindings for the [ChESS corner detector](https://github.com/VitalyVorobyev/chess-corners-rs). Detect chessboard corners with subpixel accuracy directly in the browser.
 
-## Building
+> Previously published as **`chess-corners-wasm`** on npm (≤ 0.6.x). The
+> package was renamed to `@vitavision/chess-corners` in 0.7.0; the
+> legacy name is deprecated. Migrate by replacing your dependency name —
+> the API is unchanged.
+
+## Installation
+
+```bash
+npm install @vitavision/chess-corners
+```
+
+## Building from source
 
 Requires [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/):
 
@@ -10,7 +21,10 @@ Requires [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/):
 wasm-pack build crates/chess-corners-wasm --target web
 ```
 
-The npm-ready package is generated in `crates/chess-corners-wasm/pkg/`.
+The npm-ready package is generated in `crates/chess-corners-wasm/pkg/`
+under the `@vitavision/chess-corners` name (the published name is set
+by the release workflow; locally `wasm-pack` derives it from the Rust
+crate name `chess-corners-wasm`).
 
 To target a bundler (Webpack, Vite, etc.) instead:
 
@@ -18,22 +32,12 @@ To target a bundler (Webpack, Vite, etc.) instead:
 wasm-pack build crates/chess-corners-wasm --target bundler
 ```
 
-## Installation
-
-After building, install the package from the local `pkg/` directory:
-
-```bash
-npm install ./crates/chess-corners-wasm/pkg
-```
-
-Or copy `pkg/` into your project and reference it directly.
-
 ## Usage
 
 ### Initialization
 
 ```js
-import init, { ChessDetector } from 'chess-corners-wasm';
+import init, { ChessDetector } from '@vitavision/chess-corners';
 
 // Initialize the WASM module (required once before any API calls).
 await init();


### PR DESCRIPTION
## Summary

- Rename the published npm package from the unscoped \`chess-corners-wasm\` to the scoped **\`@vitavision/chess-corners\`** for the 0.7.0 release. The Rust crate name (\`chess-corners-wasm\`) is unchanged — only the npm artifact name moves.
- Companion one-shot \`workflow_dispatch\` workflow publishes a tombstone version of the legacy \`chess-corners-wasm\` package and runs \`npm deprecate\` so existing consumers see a migration prompt.
- Docs/README/CHANGELOG/CLAUDE.md updated to reference the new package name; build paths \`crates/chess-corners-wasm/...\` stay since the Rust crate is unchanged.

## Why a post-build rewrite, not \`--scope\`

\`wasm-pack build --scope vitavision\` would produce \`@vitavision/chess-corners-wasm\` (suffix preserved). Since we want \`@vitavision/chess-corners\` (no \`-wasm\`), the release workflow runs a \`jq\` patch on \`pkg/package.json\` after \`wasm-pack build\`. Renaming the Rust crate would be more invasive (touches every workspace consumer's path imports) for zero functional benefit.

## Files changed

- \`.github/workflows/release-npm.yml\` — added \`Rename npm package\` step.
- \`.github/workflows/release-npm-deprecate.yml\` *(new)* — manual workflow_dispatch with configurable \`tombstone_version\` (default \`0.6.99\`); patches \`pkg/package.json\` to the legacy name + tombstone version + MOVED README, publishes, then runs \`npm deprecate chess-corners-wasm@<=tombstone\`.
- \`README.md\`, \`crates/chess-corners-wasm/README.md\`, \`CHANGELOG.md\`, \`CLAUDE.md\` — install/import strings point to \`@vitavision/chess-corners\`; \"previously published as\" callouts.

## Test plan

- [x] YAML syntax-validated both workflows with \`yaml.safe_load\`.
- [x] \`mdbook build book\` clean.
- [ ] After merge, push tag \`wasm-v0.7.0\` to trigger the rename workflow; verify \`npm view @vitavision/chess-corners version\` returns 0.7.0.
- [ ] Then run the \`Deprecate legacy npm package\` workflow once with default \`tombstone_version\`; verify \`npm view chess-corners-wasm\` shows the deprecation message.

## Versioning

The 0.7.0 bump itself is **not** in this PR — the workspace version stays at 0.6.0 here. Bump in a separate commit once Phases B and C land (so the 0.7.0 changelog entry covers all three).

🤖 Generated with [Claude Code](https://claude.com/claude-code)