### PR TITLE
feat: typed ChessConfig surface for WASM bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.0] - 2026-04-26
 
 ### Changed
 
@@ -14,12 +14,78 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   formerly published as `chess-corners-wasm`) now publish under the
   scoped name `@vitavision/chess-corners`. The Rust crate name is
   unchanged; only the npm package name moves. The legacy
-  `chess-corners-wasm` package is being deprecated on npm via a
-  one-shot tombstone release that points users at the new name. The
-  exported JS API is identical — migrate by replacing the dependency
-  name in `package.json` / your `import` statements.
+  `chess-corners-wasm` package is deprecated on npm via a one-shot
+  tombstone release that points users at the new name. The exported
+  JS API is identical — migrate by replacing the dependency name in
+  `package.json` / your `import` statements.
+
+- **WASM typed config wrappers use shared `Rc<RefCell<T>>` cells.**
+  Chained nested edits (`cfg.refiner.kind = X`,
+  `cfg.refiner.forstner.maxOffset = 2.0`,
+  `cfg.radonDetector.rayRadius = 5`) now propagate through the
+  parent without a round-trip — matching the live-view semantics
+  already provided by the Python typed FFI. Setters that take a
+  nested wrapper (`cfg.refiner = newOne`) reseat the parent's `Rc`s;
+  previously-captured wrappers continue to observe their original
+  cells, matching natural JS attribute-replacement semantics.
+  Single-threaded `Rc<RefCell<T>>` is sound on
+  `wasm32-unknown-unknown` (no worker-thread sharing).
+
+- `RadonPeakRefiner` now implements the full Duda-Frese (2018)
+  pipeline: image supersampling, response-map box blur, and Gaussian
+  (log-space) peak fit. Default accuracy is ~0.04 px mean on clean
+  anti-aliased chessboards, competitive with and often beating
+  `SaddlePoint`. The module doc no longer calls this a "first cut"
+  implementation.
+
+- `RadonPeakConfig` field renames and additions: the previous
+  `upsample` (response-grid density only) is replaced by
+  `image_upsample` (controls both ray-sample spacing and
+  response-grid density); new `response_blur_radius` and `peak_fit`
+  fields gate the post-blur and Gaussian-fit stages. Defaults
+  (`ray_radius = 2`, `patch_radius = 3`, `image_upsample = 2`,
+  `response_blur_radius = 1`, `peak_fit = Gaussian`) match the paper.
 
 ### Added
+
+- **Radon heatmap exposure.** The dense
+  `(max_α S_α − min_α S_α)²` Radon response is now a first-class
+  public API on every layer — Rust facade
+  `chess_corners::radon_heatmap_u8` (plus `radon_heatmap_image`
+  under the `image` feature), Python `chess_corners.radon_heatmap()`,
+  and WASM `ChessDetector::{radon_heatmap, radon_heatmap_rgba,
+  radon_heatmap_width, radon_heatmap_height, radon_heatmap_scale}`.
+  The heatmap is returned at *working resolution*
+  (`width × upscale × radon_image_upsample`); each wrapper surfaces
+  the working-to-input scale factor. The WASM scale getter caches
+  the value at compute time so width/height/scale stay mutually
+  consistent across mid-stream config edits. The interactive demo
+  gains a "Radon heatmap" overlay toggle and a "Detector mode"
+  selector (canonical / broad / radon).
+
+- **Native typed `ChessConfig` in WASM.** New `#[wasm_bindgen]`
+  wrappers (`ChessConfig`, `RefinerConfig`, `CenterOfMassConfig`,
+  `ForstnerConfig`, `SaddlePointConfig`, `RadonPeakConfig`,
+  `RadonDetectorParams`, `UpscaleConfig`, plus enums `DetectorMode`,
+  `DescriptorMode`, `ThresholdMode`, `RefinementMethod`,
+  `PeakFitMode`, `UpscaleMode`) expose every public Rust facade
+  field with TypeScript-typed getters/setters. New
+  `ChessDetector.withConfig(cfg)` / `getConfig()` / `applyConfig(cfg)`
+  close the previous tunability gap: refiner subconfig, Radon params,
+  descriptor mode, and coarse-to-fine radii were previously locked
+  to defaults from JS. The legacy `set_*` shortcut methods continue
+  to work.
+
+- **Native typed PyO3 `ChessConfig` surface.** Replaces the previous
+  Python dataclass + JSON-string FFI with native PyO3 `#[pyclass]`
+  wrappers. The Python user surface is unchanged (attribute access,
+  classmethod factories, `to_dict`/`from_dict`/`to_json`/`from_json`/
+  `pretty`/`print`, identity-comparable enum members) but detection
+  no longer serializes through JSON across the FFI boundary —
+  `find_chess_corners(image, cfg)` hands the typed object directly
+  to Rust. Nested edits (`cfg.refiner.forstner.max_offset = 2.0`)
+  work through PyO3 `Py<X>` reference semantics. The JSON-string FFI
+  fallback is retained for one release.
 
 - **`DetectorMode::Radon`** — the whole-image Duda-Frese Radon
   detector is now selectable from the facade. `ChessConfig` gains a
@@ -31,25 +97,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the facade gap from the M1 release. See
   [`docs/detector-comparison.md`](docs/detector-comparison.md) for
   when to pick each detector.
-- Facade-level integration test
-  (`crates/chess-corners/tests/radon_pipeline.rs`) pins the
-  end-to-end contract: `DetectorMode::Radon` beats ChESS defaults
-  on a hostile (heavy blur + narrow contrast) fixture, both modes
-  recover most corners on a clean board, and Radon's subpixel
-  output snaps to a ground-truth grid with mean error < 0.2 px on
-  the locked-on subset.
-- Criterion bench
-  (`crates/chess-corners-core/benches/radon_response.rs`) comparing
-  `radon_response_u8` (`image_upsample ∈ {1, 2}`) against
-  `chess_response_u8` at 640×480 / 1280×720 / 1920×1080.
-- WASM bindings (`crates/chess-corners-wasm`): new
-  `set_detector_mode("canonical"|"broad"|"radon")`; `set_refiner`
-  now also accepts `"radon_peak"`.
+
+- Whole-image Duda-Frese Radon detector in
+  `chess-corners-core` as an alternative to the ChESS ring kernel
+  for hard frames (heavy blur, low contrast, cells smaller than
+  `~2·ring_radius`). Exposes
+  [`RadonDetectorParams`](crates/chess-corners-core/src/radon_detector.rs),
+  [`RadonBuffers`](crates/chess-corners-core/src/radon_detector.rs),
+  [`radon_response_u8`](crates/chess-corners-core/src/radon_detector.rs),
+  and `detect_corners_from_radon`. Pipeline: optional 2× bilinear
+  upsample → 4 summed-area tables (row/col/±diag) → `(max−min)²`
+  response → box blur → threshold+NMS → 3-point Gaussian peak fit.
+
+- New shared `chess_corners_core::radon` module holds primitives
+  that both the refiner and the detector depend on: `DIR_COS/SIN`,
+  `ANGLES`, `PeakFitMode`, `fit_peak_frac`, and `box_blur_inplace`.
+  `refine_radon.rs` now imports these instead of defining them
+  locally, so there is exactly one source of truth for the angular
+  basis and peak-fit math.
+
+- Feature `radon-sat-u32` (opt-in) switches the detector's
+  summed-area-table element type from `i64` to `u32`. Halves SAT
+  memory and widens SIMD lanes at the cost of a ~16 MP image-size
+  cap (`255·W·H ≤ u32::MAX`).
+
+- WASM bindings (`crates/chess-corners-wasm`): legacy setter
+  shortcuts gain `set_detector_mode("canonical"|"broad"|"radon")`
+  and `set_refiner` accepts `"radon_peak"`. Threshold / NMS /
+  cluster-size setters mirror into both ChESS and Radon paths so
+  detector-mode toggles preserve tuning.
+
 - Python bindings (`crates/chess-corners-py`): `DetectorMode.RADON`
   and `RefinementMethod.RADON_PEAK` enum members, `PeakFitMode`,
-  `RadonPeakConfig`, and `RadonDetectorParams` dataclasses,
-  `ChessConfig.radon_detector` field, and a
-  `ChessConfig.radon()` classmethod.
+  `RadonPeakConfig`, `RadonDetectorParams`, and
+  `ChessConfig.radon_detector` field; `ChessConfig.radon()`
+  classmethod; `find_chess_corners_with_ml` under the `ml-refiner`
+  feature.
+
 - ML refiner v4 (`chess_refiner_v4.onnx`) — retrained on a 50/50
   mix of AA hard-cell chessboards and legacy tanh saddles so the
   shipped model handles both distributions without the
@@ -57,6 +141,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is the first ML refiner to land inside the shipping band on
   `cell=8` clean data (~0.09 px mean) and stays flattest under
   heavy noise (0.10 px at σ=12).
+
 - Part V of the book rewritten with a six-refiner comparison
   (CenterOfMass, Förstner, SaddlePoint, RadonPeak, ML v4,
   `cv2.cornerSubPix`) on the shared synthetic fixture. Plots now
@@ -64,7 +149,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   good refiners remain distinguishable regardless of Förstner's
   blur-driven failures.
 
+- Facade-level integration test
+  (`crates/chess-corners/tests/radon_pipeline.rs`) pins the
+  end-to-end contract: `DetectorMode::Radon` beats ChESS defaults
+  on a hostile (heavy blur + narrow contrast) fixture, both modes
+  recover most corners on a clean board, and Radon's subpixel
+  output snaps to a ground-truth grid with mean error < 0.2 px on
+  the locked-on subset.
+
+- Criterion bench
+  (`crates/chess-corners-core/benches/radon_response.rs`) comparing
+  `radon_response_u8` (`image_upsample ∈ {1, 2}`) against
+  `chess_response_u8` at 640×480 / 1280×720 / 1920×1080.
+
+- New cross-refiner accuracy integration test
+  (`crates/chess-corners-core/tests/refiner_accuracy.rs`) prints a
+  summary table for `RadonPeak` / `SaddlePoint` / `Forstner` across
+  subpixel offset, blur, and noise sweeps.
+
+- New unified accuracy+throughput benchmark
+  (`crates/chess-corners/tests/refiner_benchmark.rs`) covering all
+  five refiners — `CenterOfMass`, `Forstner`, `SaddlePoint`,
+  `RadonPeak`, and (under the `ml-refiner` feature) the embedded
+  ONNX `ML` refiner — over clean, blurred, and noisy sweeps with
+  per-refiner timing. Run via
+  `cargo test --release -p chess-corners --test refiner_benchmark \
+   --features ml-refiner -- --nocapture --test-threads=1`.
+
+- `crates/chess-corners-core/tests/radon_parity.rs` pins the shared
+  primitive extraction by asserting that axial ray sums match
+  between the detector SAT path and the refiner bilinear path, and
+  that detector and refiner subpixel peaks coincide to under 0.1 px
+  on clean corners.
+
+- `crates/chess-corners-core/tests/radon_vs_chess.rs` compares the
+  new detector against ChESS on a deliberately hostile fixture
+  (blurred, low-contrast board) to prove the Radon path recovers
+  corners that ChESS misses.
+
+- Design proposals at `docs/proposal-radon-detector.md` and
+  `docs/proposal-ml-refiner-v3.md`.
+
 ### Fixed
+
+- **Race in embedded ONNX model writes under parallel tests.** The
+  `chess-corners-ml` embedded-model loader used `OnceLock` only as
+  a result-cache; multiple threads in the parallel `sweep_*`
+  benchmark could enter the unconditional `std::fs::write`
+  simultaneously, with one thread's `O_TRUNC` truncating
+  `.onnx.data` to 0 bytes mid-rewrite while another thread's
+  `tract_onnx::onnx().model_for_path` was lazily dereferencing the
+  external-data file — yielding `range start index 768 out of
+  range for slice of length 0` in CI. Fix: serialize the writes
+  via `OnceLock::get_or_init`, switch to atomic
+  write-then-rename, and write `.onnx.data` before `.onnx`.
+
+- **WASM `radon_heatmap_scale()` cached at compute time.**
+  Previously recomputed from the live config every call, so
+  callers that mutated `set_upscale_factor` /
+  `radon_detector.image_upsample` between heatmap call and
+  accessor calls observed inconsistent width / height / scale.
+  Now snapshotted alongside `last_radon_response`.
 
 - `chess_corners_core::radon::box_blur_inplace` now takes
   `(w, h)` instead of a single `side` parameter. The detector
@@ -72,34 +217,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   only `ww`, which indexed out of bounds on any non-square input
   (reproduces on every real-world frame). The refiner's square
   patch path is unaffected.
+
 - `chess_corners_core::RadonDetectorParams::image_upsample` is now
   clamped into the supported set `{1, 2}`. Values `≥ 3` used to
   route through `upsample_bilinear_2x_if_needed` (2×-only) while
   downstream cumsum expected `(up·w)·(up·h)` — a release-build
   panic. Values are clamped to `MAX_IMAGE_UPSAMPLE` at the entry
   points instead.
-- `chess_corners_core::detect::{is_local_max, count_positive_neighbors}`
-  refactored to take `(data, w, h, …)` slice arguments so the Radon
-  detector no longer clones its full-frame response into a
-  `ResponseMap` before NMS — a noticeable win at `image_upsample=2`
-  on HD frames.
+
+- `chess_corners_core::detect::{is_local_max,
+  count_positive_neighbors}` refactored to take `(data, w, h, …)`
+  slice arguments so the Radon detector no longer clones its
+  full-frame response into a `ResponseMap` before NMS — a
+  noticeable win at `image_upsample = 2` on HD frames.
+
 - Under the `radon-sat-u32` feature, `radon_response_u8` now
   validates `255·W·H ≤ u32::MAX` up front and panics with an
   explicit message instead of silently wrapping the cumsum
   accumulators in release builds.
+
 - `chess_corners_core::refine_radon::RadonPeakRefiner::response_at`
   now uses `image_upsample_clamped()` so ray sampling stays
   consistent with the response-map grid when a config with
   `image_upsample == 0` slips through serde.
+
 - `chess-corners` re-exports `PeakFitMode` so downstream consumers
   can set `RadonPeakConfig.peak_fit` without adding a direct
   `chess-corners-core` dependency.
+
 - `tools/book/opencv_subpix_sweep.py` matches Rust's
   half-away-from-zero rounding (Python's built-in `round` is
   banker's rounding) and excludes fixture construction from the
   timed block. Throughput numbers for `cv2.cornerSubPix` in Part V
   drop from ~300 µs/call to ~2.7 µs/call because the previous
   figure was timing the fixture render, not the refinement.
+
 - **Retrained ML refiner** (`chess_refiner_v4.onnx`) on a mixed
   training distribution — 50% AA-rasterised hard-cell chessboards
   that match the benchmark fixture, 50% legacy tanh-saddle patches
@@ -157,76 +309,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the crate and confused the parity tests. `v4.onnx` is now the
   only embedded artifact.
 
-### Changed
+### Deferred
 
-- `RadonPeakRefiner` now implements the full Duda-Frese (2018) pipeline:
-  image supersampling, response-map box blur, and Gaussian (log-space)
-  peak fit. Default accuracy is ~0.04 px mean on clean anti-aliased
-  chessboards, competitive with and often beating `SaddlePoint`. The
-  module doc no longer calls this a "first cut" implementation.
-
-- `RadonPeakConfig` field renames and additions: the previous
-  `upsample` (response-grid density only) is replaced by
-  `image_upsample` (controls both ray-sample spacing and
-  response-grid density); new `response_blur_radius` and `peak_fit`
-  fields gate the post-blur and Gaussian-fit stages. Defaults
-  (`ray_radius = 2`, `patch_radius = 3`, `image_upsample = 2`,
-  `response_blur_radius = 1`, `peak_fit = Gaussian`) match the paper.
-
-- New cross-refiner accuracy integration test
-  (`crates/chess-corners-core/tests/refiner_accuracy.rs`) prints a
-  summary table for `RadonPeak` / `SaddlePoint` / `Forstner` across
-  subpixel offset, blur, and noise sweeps.
-
-- New unified accuracy+throughput benchmark
-  (`crates/chess-corners/tests/refiner_benchmark.rs`) covering all
-  five refiners — `CenterOfMass`, `Forstner`, `SaddlePoint`,
-  `RadonPeak`, and (under the `ml-refiner` feature) the embedded
-  ONNX `ML` refiner — over clean, blurred, and noisy sweeps with
-  per-refiner timing. Run via
-  `cargo test --release -p chess-corners --test refiner_benchmark \
-   --features ml-refiner -- --nocapture --test-threads=1`.
-
-### Added
-
-- Whole-image Duda-Frese Radon detector in
-  `chess-corners-core` as an alternative to the ChESS ring kernel
-  for hard frames (heavy blur, low contrast, cells smaller than
-  `~2·ring_radius`). Exposes
-  [`RadonDetectorParams`](crates/chess-corners-core/src/radon_detector.rs),
-  [`RadonBuffers`](crates/chess-corners-core/src/radon_detector.rs),
-  [`radon_response_u8`](crates/chess-corners-core/src/radon_detector.rs),
-  and `detect_corners_from_radon`. Pipeline: optional 2× bilinear
-  upsample → 4 summed-area tables (row/col/±diag) → `(max−min)²`
-  response → box blur → threshold+NMS → 3-point Gaussian peak fit.
-  Facade integration lands in the same release via
-  `DetectorMode::Radon` on `ChessConfig` (see the M2 entry above).
-
-- New shared `chess_corners_core::radon` module holds primitives
-  that both the refiner and the detector depend on: `DIR_COS/SIN`,
-  `ANGLES`, `PeakFitMode`, `fit_peak_frac`, and `box_blur_inplace`.
-  `refine_radon.rs` now imports these instead of defining them
-  locally, so there is exactly one source of truth for the angular
-  basis and peak-fit math.
-
-- Feature `radon-sat-u32` (opt-in) switches the detector's
-  summed-area-table element type from `i64` to `u32`. Halves SAT
-  memory and widens SIMD lanes at the cost of a ~16 MP image-size
-  cap (`255·W·H ≤ u32::MAX`).
-
-- New tests:
-  `crates/chess-corners-core/tests/radon_parity.rs` pins the shared
-  primitive extraction by asserting that axial ray sums match
-  between the detector SAT path and the refiner bilinear path, and
-  that detector and refiner subpixel peaks coincide to under 0.1 px
-  on clean corners.
-  `crates/chess-corners-core/tests/radon_vs_chess.rs` compares the
-  new detector against ChESS on a deliberately hostile fixture
-  (blurred, low-contrast board) to prove the Radon path recovers
-  corners that ChESS misses.
-
-- Design proposals at `docs/proposal-radon-detector.md` (this work)
-  and `docs/proposal-ml-refiner-v3.md` (future ML retraining).
+- **ML refiner cross-compile to `wasm32-unknown-unknown`.** Probed
+  during the typed-config work and documented as a known gap.
+  Blocked by (1) `getrandom` requiring the `js` feature on
+  `wasm32-unknown-unknown`, and more fundamentally
+  (2) the embedded-model loader writing ONNX bytes to `/tmp` and
+  re-reading via `tract_onnx::onnx().model_for_path` — no
+  filesystem in WASM. Refactoring to tract's in-memory
+  `model_for_read` is feasible but is its own R&D + ~1–2 MB
+  binary-size hit before wasm-opt.
 
 ## [0.6.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,17 +248,17 @@ checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitstream-io"
-version = "4.9.0"
+version = "4.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
 dependencies = [
- "core2",
+ "no_std_io2",
 ]
 
 [[package]]
@@ -327,9 +327,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -438,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -460,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -487,15 +487,6 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -732,9 +723,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"
@@ -871,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
  "weezl",
@@ -911,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -969,12 +960,12 @@ checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1050,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.93"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797146bb2677299a1eb6b7b50a890f4c361b29ef967addf5b2fa45dae1bb6d7d"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1090,9 +1081,9 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1112,14 +1103,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -1341,6 +1332,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "nom"
@@ -1630,9 +1630,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -1724,9 +1724,9 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "py_literal"
@@ -1743,9 +1743,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf85e27e86080aafd5a22eae58a162e133a589551542b3e5cee4beb27e54f8e1"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
  "libc",
  "once_cell",
@@ -1757,18 +1757,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf94ee265674bf76c09fa430b0e99c26e319c945d96ca0d5a8215f31bf81cf7"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491aa5fc66d8059dd44a75f4580a2962c1862a1c2945359db36f6c2818b748dc"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1776,9 +1776,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d671734e9d7a43449f8480f8b38115df67bef8d21f76837fa75ee7aaa5e52e"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1788,9 +1788,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22faaa1ce6c430a1f71658760497291065e6450d7b5dc2bcf254d49f66ee700a"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1837,9 +1837,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1848,9 +1848,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -1901,7 +1901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1931,7 +1931,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror",
@@ -1962,9 +1962,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1991,9 +1991,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -2121,9 +2121,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2618,7 +2618,7 @@ checksum = "87561bf0b84f74a124afc0f1997682728da6cd821083511e0357432954fd24f6"
 dependencies = [
  "getrandom 0.2.17",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_distr",
  "rustfft",
  "tract-nnef",
@@ -2636,9 +2636,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -2720,11 +2720,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -2733,14 +2733,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.116"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dc0882f7b5bb01ae8c5215a1230832694481c1a4be062fd410e12ea3da5b631"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2751,9 +2751,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.66"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19280959e2844181895ef62f065c63e0ca07ece4771b53d89bfdb967d97cbf05"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2761,9 +2761,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.116"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75973d3066e01d035dbedaad2864c398df42f8dd7b1ea057c35b8407c015b537"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2771,9 +2771,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.116"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91af5e4be765819e0bcfee7322c14374dc821e35e72fa663a830bbc7dc199eac"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2784,18 +2784,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.116"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9bf0406a78f02f336bf1e451799cca198e8acde4ffa278f0fb20487b150a633"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.66"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea88331fc76766356287e79bb0bc032157feea8eff8f2c3f1d9ea4b94255ae1c"
+checksum = "6bb55e2540ad1c56eec35fd63e2aea15f83b11ce487fd2de9ad11578dfc047ea"
 dependencies = [
  "async-trait",
  "cast",
@@ -2815,9 +2815,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.66"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92437fa87f58743befb3003c4f4e3e9010dd50c6935561be7645981c0de05dfd"
+checksum = "caf0ca1bd612b988616bac1ab34c4e4290ef18f7148a1d8b7f31c150080e9295"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2826,9 +2826,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.116"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10091e48e3231b0f567b098ddb9a107310eb2629ae0eaa7c98dd746d5e80ee78"
+checksum = "23cda5ecc67248c48d3e705d3e03e00af905769b78b9d2a1678b663b8b9d4472"
 
 [[package]]
 name = "wasm-encoder"
@@ -2866,9 +2866,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.93"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "749466a37ee189057f54748b200186b59a03417a117267baf3fd89cecc9fb837"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2934,6 +2934,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "box-image-pyramid"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "fast_image_resize",
@@ -345,7 +345,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chess-corners"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "box-image-pyramid",
@@ -364,7 +364,7 @@ dependencies = [
 
 [[package]]
 name = "chess-corners-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "image",
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "chess-corners-ml"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "ndarray 0.17.2",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "chess-corners-py"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chess-corners",
  "numpy",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "chess-corners-wasm"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chess-corners",
  "chess-corners-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,17 +10,17 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/VitalyVorobyev/chess-corners-rs"
 
 [workspace.dependencies]
 anyhow = "1"
-box-image-pyramid = { path = "crates/box-image-pyramid", version = "0.6.0" }
-chess-corners = { path = "crates/chess-corners", version = "0.6.0", default-features = false }
-chess-corners-core = { path = "crates/chess-corners-core", version = "0.6.0" }
-chess-corners-ml = { path = "crates/chess-corners-ml", version = "0.6.0" }
+box-image-pyramid = { path = "crates/box-image-pyramid", version = "0.7.0" }
+chess-corners = { path = "crates/chess-corners", version = "0.7.0", default-features = false }
+chess-corners-core = { path = "crates/chess-corners-core", version = "0.7.0" }
+chess-corners-ml = { path = "crates/chess-corners-ml", version = "0.7.0" }
 clap = { version = "4.6", features = ["derive"] }
 criterion = "0.8"
 fast_image_resize = { version = "6", features = ["image"] }

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ and every optional dependency is feature-gated. See `AGENTS.md` and
 
 ```toml
 [dependencies]
-chess-corners = "0.5"
+chess-corners = "0.7"
 image = "0.25"
 ```
 

--- a/crates/chess-corners-py/python/chess_corners/__init__.py
+++ b/crates/chess-corners-py/python/chess_corners/__init__.py
@@ -1,596 +1,84 @@
-"""Python-first public API for the chess_corners detector."""
+"""Python-first public API for the chess_corners detector.
+
+The config classes (`ChessConfig`, `RefinerConfig`, …) and enums
+(`DetectorMode`, `RefinementMethod`, …) are native PyO3 types defined
+in the compiled `_native` extension. They expose the same surface as
+the prior pure-Python dataclasses — attribute access, classmethod
+factories (`ChessConfig.multiscale()`), `to_dict` / `from_dict` /
+`to_json` / `from_json`, identity-comparable enum members
+(`cfg.detector_mode is DetectorMode.BROAD`) — but the FFI no longer
+serializes through JSON: `find_chess_corners(image, cfg)` hands the
+typed object directly to Rust.
+"""
 
 from __future__ import annotations
 
-import json
 import sys
-from dataclasses import dataclass, field
-from enum import Enum
-from pathlib import Path
-from typing import Any, Mapping, Optional, TextIO
+from typing import Any, TextIO
 
 from . import _native
+from ._native import (
+    CenterOfMassConfig,
+    ChessConfig,
+    ConfigError,
+    DescriptorMode,
+    DetectorMode,
+    ForstnerConfig,
+    PeakFitMode,
+    RadonDetectorParams,
+    RadonPeakConfig,
+    RefinementMethod,
+    RefinerConfig,
+    SaddlePointConfig,
+    ThresholdMode,
+)
 
 
-JsonDict = dict[str, Any]
+def _print(self: Any, *, file: TextIO | None = None, indent: int = 2, sort_keys: bool = True) -> None:
+    """Pretty-print a config object, using ``rich`` when available.
 
+    Attached to every config class below so that
+    ``ChessConfig().print()`` keeps working from earlier versions.
+    """
 
-class ConfigError(ValueError):
-    """Raised when a config dictionary or JSON document is invalid."""
-
-
-def _expect_mapping(value: Any, path: str) -> Mapping[str, Any]:
-    if not isinstance(value, Mapping):
-        raise ConfigError(f"{path} must be an object")
-    return value
-
-
-def _reject_unknown_keys(data: Mapping[str, Any], allowed: set[str], path: str) -> None:
-    unknown = sorted(set(data) - allowed)
-    if unknown:
-        joined = ", ".join(unknown)
-        raise ConfigError(f"{path} has unknown keys: {joined}")
-
-
-def _expect_int(value: Any, path: str) -> int:
-    if isinstance(value, bool) or not isinstance(value, int):
-        raise ConfigError(f"{path} must be an integer")
-    return value
-
-
-def _expect_float(value: Any, path: str) -> float:
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        raise ConfigError(f"{path} must be a number")
-    return float(value)
-
-
-def _expect_string(value: Any, path: str) -> str:
-    if not isinstance(value, str):
-        raise ConfigError(f"{path} must be a string")
-    return value
-
-
-def _enum_value(enum_type: type[Enum], value: Any, path: str) -> Enum:
-    raw = _expect_string(value, path)
-    try:
-        return enum_type(raw)
-    except ValueError as exc:
-        allowed = ", ".join(item.value for item in enum_type)
-        raise ConfigError(f"{path} must be one of: {allowed}") from exc
-
-
-class _PrettyMixin:
-    """Shared JSON/pretty-print helpers for public config objects."""
-
-    def to_dict(self) -> JsonDict:
-        raise NotImplementedError
-
-    def to_json(self, *, indent: int | None = None, sort_keys: bool = True) -> str:
-        return json.dumps(self.to_dict(), indent=indent, sort_keys=sort_keys)
-
-    def pretty(self, *, indent: int = 2, sort_keys: bool = True) -> str:
-        return self.to_json(indent=indent, sort_keys=sort_keys)
-
-    def print(
-        self,
-        *,
-        file: TextIO | None = None,
-        indent: int = 2,
-        sort_keys: bool = True,
-    ) -> None:
-        if file is None:
-            try:
-                from rich.console import Console
-            except ImportError:
-                pass
-            else:
-                Console().print(self)
-                return
-        print(self.pretty(indent=indent, sort_keys=sort_keys), file=file or sys.stdout)
-
-    def __str__(self) -> str:
-        return self.pretty()
-
-    def __rich_console__(self, console: Any, options: Any) -> Any:
+    if file is None:
         try:
-            from rich.panel import Panel
-            from rich.pretty import Pretty
+            from rich.console import Console
         except ImportError:
-            yield self.pretty()
+            pass
+        else:
+            Console().print(self)
             return
-
-        yield Panel(Pretty(self.to_dict(), expand_all=True), title=type(self).__name__)
-
-
-class DetectorMode(str, Enum):
-    """High-level detector mode: ChESS variants or whole-image Radon."""
-
-    CANONICAL = "canonical"
-    BROAD = "broad"
-    RADON = "radon"
+    print(self.pretty(indent=indent, sort_keys=sort_keys), file=file or sys.stdout)
 
 
-class DescriptorMode(str, Enum):
-    """High-level descriptor mode for orientation/response sampling."""
-
-    FOLLOW_DETECTOR = "follow_detector"
-    CANONICAL = "canonical"
-    BROAD = "broad"
-
-
-class ThresholdMode(str, Enum):
-    """Threshold interpretation for candidate selection."""
-
-    RELATIVE = "relative"
-    ABSOLUTE = "absolute"
+def _rich_console(self: Any, console: Any, options: Any) -> Any:
+    try:
+        from rich.panel import Panel
+        from rich.pretty import Pretty
+    except ImportError:
+        yield self.pretty()
+        return
+    yield Panel(Pretty(self.to_dict(), expand_all=True), title=type(self).__name__)
 
 
-class RefinementMethod(str, Enum):
-    """Subpixel refinement algorithm applied to each candidate."""
-
-    CENTER_OF_MASS = "center_of_mass"
-    FORSTNER = "forstner"
-    SADDLE_POINT = "saddle_point"
-    RADON_PEAK = "radon_peak"
-
-
-@dataclass
-class CenterOfMassConfig(_PrettyMixin):
-    """Classic center-of-mass refiner parameters."""
-
-    radius: int = 2
-
-    @classmethod
-    def from_dict(cls, data: Mapping[str, Any]) -> CenterOfMassConfig:
-        mapping = _expect_mapping(data, "center_of_mass")
-        _reject_unknown_keys(mapping, {"radius"}, "center_of_mass")
-        cfg = cls()
-        if "radius" in mapping:
-            cfg.radius = _expect_int(mapping["radius"], "center_of_mass.radius")
-        return cfg
-
-    def to_dict(self) -> JsonDict:
-        return {"radius": self.radius}
-
-
-@dataclass
-class ForstnerConfig(_PrettyMixin):
-    """Förstner refiner parameters."""
-
-    radius: int = 2
-    min_trace: float = 25.0
-    min_det: float = 1e-3
-    max_condition_number: float = 50.0
-    max_offset: float = 1.5
-
-    @classmethod
-    def from_dict(cls, data: Mapping[str, Any]) -> ForstnerConfig:
-        mapping = _expect_mapping(data, "forstner")
-        _reject_unknown_keys(
-            mapping,
-            {
-                "radius",
-                "min_trace",
-                "min_det",
-                "max_condition_number",
-                "max_offset",
-            },
-            "forstner",
-        )
-        cfg = cls()
-        if "radius" in mapping:
-            cfg.radius = _expect_int(mapping["radius"], "forstner.radius")
-        if "min_trace" in mapping:
-            cfg.min_trace = _expect_float(mapping["min_trace"], "forstner.min_trace")
-        if "min_det" in mapping:
-            cfg.min_det = _expect_float(mapping["min_det"], "forstner.min_det")
-        if "max_condition_number" in mapping:
-            cfg.max_condition_number = _expect_float(
-                mapping["max_condition_number"],
-                "forstner.max_condition_number",
-            )
-        if "max_offset" in mapping:
-            cfg.max_offset = _expect_float(mapping["max_offset"], "forstner.max_offset")
-        return cfg
-
-    def to_dict(self) -> JsonDict:
-        return {
-            "radius": self.radius,
-            "min_trace": self.min_trace,
-            "min_det": self.min_det,
-            "max_condition_number": self.max_condition_number,
-            "max_offset": self.max_offset,
-        }
-
-
-@dataclass
-class SaddlePointConfig(_PrettyMixin):
-    """Quadratic saddle-point refiner parameters."""
-
-    radius: int = 2
-    det_margin: float = 1e-3
-    max_offset: float = 1.5
-    min_abs_det: float = 1e-4
-
-    @classmethod
-    def from_dict(cls, data: Mapping[str, Any]) -> SaddlePointConfig:
-        mapping = _expect_mapping(data, "saddle_point")
-        _reject_unknown_keys(
-            mapping,
-            {"radius", "det_margin", "max_offset", "min_abs_det"},
-            "saddle_point",
-        )
-        cfg = cls()
-        if "radius" in mapping:
-            cfg.radius = _expect_int(mapping["radius"], "saddle_point.radius")
-        if "det_margin" in mapping:
-            cfg.det_margin = _expect_float(mapping["det_margin"], "saddle_point.det_margin")
-        if "max_offset" in mapping:
-            cfg.max_offset = _expect_float(mapping["max_offset"], "saddle_point.max_offset")
-        if "min_abs_det" in mapping:
-            cfg.min_abs_det = _expect_float(mapping["min_abs_det"], "saddle_point.min_abs_det")
-        return cfg
-
-    def to_dict(self) -> JsonDict:
-        return {
-            "radius": self.radius,
-            "det_margin": self.det_margin,
-            "max_offset": self.max_offset,
-            "min_abs_det": self.min_abs_det,
-        }
-
-
-class PeakFitMode(str, Enum):
-    """Subpixel peak-fit mode used by the Radon refiner and detector."""
-
-    PARABOLIC = "parabolic"
-    GAUSSIAN = "gaussian"
-
-
-@dataclass
-class RadonPeakConfig(_PrettyMixin):
-    """Local Duda-Frese Radon refiner parameters."""
-
-    ray_radius: int = 2
-    patch_radius: int = 3
-    image_upsample: int = 2
-    response_blur_radius: int = 1
-    peak_fit: PeakFitMode = PeakFitMode.GAUSSIAN
-    min_response: float = 0.0
-    max_offset: float = 1.5
-
-    @classmethod
-    def from_dict(cls, data: Mapping[str, Any]) -> RadonPeakConfig:
-        mapping = _expect_mapping(data, "radon_peak")
-        _reject_unknown_keys(
-            mapping,
-            {
-                "ray_radius",
-                "patch_radius",
-                "image_upsample",
-                "response_blur_radius",
-                "peak_fit",
-                "min_response",
-                "max_offset",
-            },
-            "radon_peak",
-        )
-        cfg = cls()
-        if "ray_radius" in mapping:
-            cfg.ray_radius = _expect_int(mapping["ray_radius"], "radon_peak.ray_radius")
-        if "patch_radius" in mapping:
-            cfg.patch_radius = _expect_int(mapping["patch_radius"], "radon_peak.patch_radius")
-        if "image_upsample" in mapping:
-            cfg.image_upsample = _expect_int(
-                mapping["image_upsample"], "radon_peak.image_upsample"
-            )
-        if "response_blur_radius" in mapping:
-            cfg.response_blur_radius = _expect_int(
-                mapping["response_blur_radius"], "radon_peak.response_blur_radius"
-            )
-        if "peak_fit" in mapping:
-            cfg.peak_fit = _enum_value(PeakFitMode, mapping["peak_fit"], "radon_peak.peak_fit")
-        if "min_response" in mapping:
-            cfg.min_response = _expect_float(mapping["min_response"], "radon_peak.min_response")
-        if "max_offset" in mapping:
-            cfg.max_offset = _expect_float(mapping["max_offset"], "radon_peak.max_offset")
-        return cfg
-
-    def to_dict(self) -> JsonDict:
-        return {
-            "ray_radius": self.ray_radius,
-            "patch_radius": self.patch_radius,
-            "image_upsample": self.image_upsample,
-            "response_blur_radius": self.response_blur_radius,
-            "peak_fit": self.peak_fit.value,
-            "min_response": self.min_response,
-            "max_offset": self.max_offset,
-        }
-
-
-@dataclass
-class RadonDetectorParams(_PrettyMixin):
-    """Whole-image Duda-Frese Radon detector parameters."""
-
-    ray_radius: int = 4
-    image_upsample: int = 2
-    response_blur_radius: int = 1
-    peak_fit: PeakFitMode = PeakFitMode.GAUSSIAN
-    threshold_rel: float = 0.01
-    threshold_abs: Optional[float] = None
-    nms_radius: int = 4
-    min_cluster_size: int = 2
-
-    @classmethod
-    def from_dict(cls, data: Mapping[str, Any]) -> RadonDetectorParams:
-        mapping = _expect_mapping(data, "radon_detector")
-        _reject_unknown_keys(
-            mapping,
-            {
-                "ray_radius",
-                "image_upsample",
-                "response_blur_radius",
-                "peak_fit",
-                "threshold_rel",
-                "threshold_abs",
-                "nms_radius",
-                "min_cluster_size",
-            },
-            "radon_detector",
-        )
-        cfg = cls()
-        if "ray_radius" in mapping:
-            cfg.ray_radius = _expect_int(mapping["ray_radius"], "radon_detector.ray_radius")
-        if "image_upsample" in mapping:
-            cfg.image_upsample = _expect_int(
-                mapping["image_upsample"], "radon_detector.image_upsample"
-            )
-        if "response_blur_radius" in mapping:
-            cfg.response_blur_radius = _expect_int(
-                mapping["response_blur_radius"], "radon_detector.response_blur_radius"
-            )
-        if "peak_fit" in mapping:
-            cfg.peak_fit = _enum_value(
-                PeakFitMode, mapping["peak_fit"], "radon_detector.peak_fit"
-            )
-        if "threshold_rel" in mapping:
-            cfg.threshold_rel = _expect_float(
-                mapping["threshold_rel"], "radon_detector.threshold_rel"
-            )
-        if "threshold_abs" in mapping:
-            value = mapping["threshold_abs"]
-            cfg.threshold_abs = (
-                None if value is None else _expect_float(value, "radon_detector.threshold_abs")
-            )
-        if "nms_radius" in mapping:
-            cfg.nms_radius = _expect_int(mapping["nms_radius"], "radon_detector.nms_radius")
-        if "min_cluster_size" in mapping:
-            cfg.min_cluster_size = _expect_int(
-                mapping["min_cluster_size"], "radon_detector.min_cluster_size"
-            )
-        return cfg
-
-    def to_dict(self) -> JsonDict:
-        return {
-            "ray_radius": self.ray_radius,
-            "image_upsample": self.image_upsample,
-            "response_blur_radius": self.response_blur_radius,
-            "peak_fit": self.peak_fit.value,
-            "threshold_rel": self.threshold_rel,
-            "threshold_abs": self.threshold_abs,
-            "nms_radius": self.nms_radius,
-            "min_cluster_size": self.min_cluster_size,
-        }
-
-
-@dataclass
-class RefinerConfig(_PrettyMixin):
-    """Flat public refiner configuration with default-initialized leaves."""
-
-    kind: RefinementMethod = RefinementMethod.CENTER_OF_MASS
-    center_of_mass: CenterOfMassConfig = field(default_factory=CenterOfMassConfig)
-    forstner: ForstnerConfig = field(default_factory=ForstnerConfig)
-    saddle_point: SaddlePointConfig = field(default_factory=SaddlePointConfig)
-    radon_peak: RadonPeakConfig = field(default_factory=RadonPeakConfig)
-
-    @classmethod
-    def center_of_mass_config(cls) -> RefinerConfig:
-        return cls(kind=RefinementMethod.CENTER_OF_MASS)
-
-    @classmethod
-    def forstner_config(cls) -> RefinerConfig:
-        return cls(kind=RefinementMethod.FORSTNER)
-
-    @classmethod
-    def saddle_point_config(cls) -> RefinerConfig:
-        return cls(kind=RefinementMethod.SADDLE_POINT)
-
-    @classmethod
-    def radon_peak_config(cls) -> RefinerConfig:
-        return cls(kind=RefinementMethod.RADON_PEAK)
-
-    @classmethod
-    def from_dict(cls, data: Mapping[str, Any]) -> RefinerConfig:
-        mapping = _expect_mapping(data, "refiner")
-        _reject_unknown_keys(
-            mapping,
-            {"kind", "center_of_mass", "forstner", "saddle_point", "radon_peak"},
-            "refiner",
-        )
-        cfg = cls()
-        if "kind" in mapping:
-            cfg.kind = _enum_value(RefinementMethod, mapping["kind"], "refiner.kind")
-        if "center_of_mass" in mapping:
-            cfg.center_of_mass = CenterOfMassConfig.from_dict(
-                _expect_mapping(mapping["center_of_mass"], "refiner.center_of_mass")
-            )
-        if "forstner" in mapping:
-            cfg.forstner = ForstnerConfig.from_dict(
-                _expect_mapping(mapping["forstner"], "refiner.forstner")
-            )
-        if "saddle_point" in mapping:
-            cfg.saddle_point = SaddlePointConfig.from_dict(
-                _expect_mapping(mapping["saddle_point"], "refiner.saddle_point")
-            )
-        if "radon_peak" in mapping:
-            cfg.radon_peak = RadonPeakConfig.from_dict(
-                _expect_mapping(mapping["radon_peak"], "refiner.radon_peak")
-            )
-        return cfg
-
-    def to_dict(self) -> JsonDict:
-        return {
-            "kind": self.kind.value,
-            "center_of_mass": self.center_of_mass.to_dict(),
-            "forstner": self.forstner.to_dict(),
-            "saddle_point": self.saddle_point.to_dict(),
-            "radon_peak": self.radon_peak.to_dict(),
-        }
-
-
-@dataclass
-class ChessConfig(_PrettyMixin):
-    """Canonical detector configuration used across Rust, Python, and CLI JSON."""
-
-    detector_mode: DetectorMode = DetectorMode.CANONICAL
-    descriptor_mode: DescriptorMode = DescriptorMode.FOLLOW_DETECTOR
-    threshold_mode: ThresholdMode = ThresholdMode.RELATIVE
-    threshold_value: float = 0.2
-    nms_radius: int = 2
-    min_cluster_size: int = 2
-    refiner: RefinerConfig = field(default_factory=RefinerConfig)
-    pyramid_levels: int = 1
-    pyramid_min_size: int = 128
-    refinement_radius: int = 3
-    merge_radius: float = 3.0
-    radon_detector: RadonDetectorParams = field(default_factory=RadonDetectorParams)
-
-    @classmethod
-    def single_scale(cls) -> ChessConfig:
-        return cls()
-
-    @classmethod
-    def multiscale(cls) -> ChessConfig:
-        return cls(pyramid_levels=3, pyramid_min_size=128)
-
-    @classmethod
-    def radon(cls) -> ChessConfig:
-        """Preset that selects the whole-image Radon detector."""
-
-        return cls(detector_mode=DetectorMode.RADON, pyramid_levels=1)
-
-    @classmethod
-    def from_dict(cls, data: Mapping[str, Any]) -> ChessConfig:
-        mapping = _expect_mapping(data, "config")
-        _reject_unknown_keys(
-            mapping,
-            {
-                "detector_mode",
-                "descriptor_mode",
-                "threshold_mode",
-                "threshold_value",
-                "nms_radius",
-                "min_cluster_size",
-                "refiner",
-                "pyramid_levels",
-                "pyramid_min_size",
-                "refinement_radius",
-                "merge_radius",
-                "radon_detector",
-            },
-            "config",
-        )
-
-        cfg = cls()
-        if "detector_mode" in mapping:
-            cfg.detector_mode = _enum_value(
-                DetectorMode,
-                mapping["detector_mode"],
-                "config.detector_mode",
-            )
-        if "descriptor_mode" in mapping:
-            cfg.descriptor_mode = _enum_value(
-                DescriptorMode,
-                mapping["descriptor_mode"],
-                "config.descriptor_mode",
-            )
-        if "threshold_mode" in mapping:
-            cfg.threshold_mode = _enum_value(
-                ThresholdMode,
-                mapping["threshold_mode"],
-                "config.threshold_mode",
-            )
-        if "threshold_value" in mapping:
-            cfg.threshold_value = _expect_float(mapping["threshold_value"], "config.threshold_value")
-        if "nms_radius" in mapping:
-            cfg.nms_radius = _expect_int(mapping["nms_radius"], "config.nms_radius")
-        if "min_cluster_size" in mapping:
-            cfg.min_cluster_size = _expect_int(
-                mapping["min_cluster_size"],
-                "config.min_cluster_size",
-            )
-        if "refiner" in mapping:
-            cfg.refiner = RefinerConfig.from_dict(
-                _expect_mapping(mapping["refiner"], "config.refiner")
-            )
-        if "pyramid_levels" in mapping:
-            cfg.pyramid_levels = _expect_int(mapping["pyramid_levels"], "config.pyramid_levels")
-        if "pyramid_min_size" in mapping:
-            cfg.pyramid_min_size = _expect_int(
-                mapping["pyramid_min_size"],
-                "config.pyramid_min_size",
-            )
-        if "refinement_radius" in mapping:
-            cfg.refinement_radius = _expect_int(
-                mapping["refinement_radius"],
-                "config.refinement_radius",
-            )
-        if "merge_radius" in mapping:
-            cfg.merge_radius = _expect_float(mapping["merge_radius"], "config.merge_radius")
-        if "radon_detector" in mapping:
-            cfg.radon_detector = RadonDetectorParams.from_dict(
-                _expect_mapping(mapping["radon_detector"], "config.radon_detector")
-            )
-        return cfg
-
-    @classmethod
-    def from_json(cls, text: str) -> ChessConfig:
-        try:
-            data = json.loads(text)
-        except json.JSONDecodeError as exc:
-            raise ConfigError(f"failed to parse config JSON: {exc}") from exc
-        return cls.from_dict(_expect_mapping(data, "config"))
-
-    @classmethod
-    def from_json_file(cls, path: str | Path) -> ChessConfig:
-        file_path = Path(path)
-        try:
-            text = file_path.read_text(encoding="utf-8")
-        except OSError as exc:
-            raise ConfigError(f"failed to read config {file_path}: {exc}") from exc
-        return cls.from_json(text)
-
-    def to_dict(self) -> JsonDict:
-        return {
-            "detector_mode": self.detector_mode.value,
-            "descriptor_mode": self.descriptor_mode.value,
-            "threshold_mode": self.threshold_mode.value,
-            "threshold_value": self.threshold_value,
-            "nms_radius": self.nms_radius,
-            "min_cluster_size": self.min_cluster_size,
-            "refiner": self.refiner.to_dict(),
-            "pyramid_levels": self.pyramid_levels,
-            "pyramid_min_size": self.pyramid_min_size,
-            "refinement_radius": self.refinement_radius,
-            "merge_radius": self.merge_radius,
-            "radon_detector": self.radon_detector.to_dict(),
-        }
+for _cls in (
+    CenterOfMassConfig,
+    ForstnerConfig,
+    SaddlePointConfig,
+    RadonPeakConfig,
+    RadonDetectorParams,
+    RefinerConfig,
+    ChessConfig,
+):
+    _cls.print = _print  # type: ignore[attr-defined]
+    _cls.__rich_console__ = _rich_console  # type: ignore[attr-defined]
 
 
 def find_chess_corners(image: Any, cfg: ChessConfig | None = None) -> Any:
     """Detect chessboard corners in a 2D C-contiguous uint8 NumPy image."""
 
-    return _native.find_chess_corners(image, None if cfg is None else cfg.to_json())
+    return _native.find_chess_corners(image, cfg)
 
 
 def radon_heatmap(image: Any, cfg: ChessConfig | None = None) -> Any:
@@ -612,17 +100,15 @@ def radon_heatmap(image: Any, cfg: ChessConfig | None = None) -> Any:
         ignored because no corner detection is performed.
     """
 
-    return _native.radon_heatmap(image, None if cfg is None else cfg.to_json())
+    return _native.radon_heatmap(image, cfg)
 
 
 if hasattr(_native, "find_chess_corners_with_ml"):
+
     def find_chess_corners_with_ml(image: Any, cfg: ChessConfig | None = None) -> Any:
         """Detect chessboard corners using the ML-backed refiner pipeline."""
 
-        return _native.find_chess_corners_with_ml(
-            image,
-            None if cfg is None else cfg.to_json(),
-        )
+        return _native.find_chess_corners_with_ml(image, cfg)
 
 
 __all__ = [

--- a/crates/chess-corners-py/python_tests/test_basic.py
+++ b/crates/chess-corners-py/python_tests/test_basic.py
@@ -99,3 +99,35 @@ def test_radon_heatmap_default_config():
     assert heatmap.ndim == 2
     assert heatmap.shape[0] >= img.shape[0]
     assert heatmap.shape[1] >= img.shape[1]
+
+
+def test_typed_config_passes_through_ffi_directly():
+    """Native typed `ChessConfig` should reach the detector without
+    JSON serialization (string fallback retained for legacy callers)."""
+
+    img = _checkerboard(square_size=16, squares=8)
+    cfg = chess_corners.ChessConfig()
+    cfg.threshold_value = 0.1
+    cfg.refiner.kind = chess_corners.RefinementMethod.FORSTNER
+    cfg.refiner.forstner.max_offset = 1.75
+
+    typed_corners = chess_corners.find_chess_corners(img, cfg)
+    json_corners = chess_corners.find_chess_corners(img, cfg.to_json())
+
+    # Both paths must produce bit-identical output (same backing
+    # algorithm, same configuration).
+    assert typed_corners.shape == json_corners.shape
+    assert np.array_equal(typed_corners, json_corners)
+
+
+def test_invalid_cfg_type_raises_type_error():
+    img = _checkerboard(square_size=16, squares=8)
+    with pytest.raises(TypeError):
+        # Plain dicts aren't accepted at the FFI boundary; they must
+        # be converted to a ChessConfig first via ChessConfig.from_dict().
+        chess_corners.find_chess_corners(img, {"threshold_value": 0.1})
+
+
+def test_unknown_top_level_keys_rejected():
+    with pytest.raises(chess_corners.ConfigError, match="unknown keys"):
+        chess_corners.ChessConfig.from_dict({"unexpected": 1})

--- a/crates/chess-corners-py/src/config.rs
+++ b/crates/chess-corners-py/src/config.rs
@@ -1,0 +1,1542 @@
+//! Native PyO3 wrappers around `chess-corners` config structs.
+//!
+//! Each wrapper owns a Rust value (or `Py<...>` handles to nested
+//! wrappers, in the case of compound types). Python-side users get
+//! attribute access, chained mutation, classmethod factories, and
+//! `to_dict`/`to_json`/`pretty`/`print` helpers identical to the
+//! prior pure-Python dataclass surface — but the FFI no longer
+//! serializes through JSON: `find_chess_corners(image, cfg)` accepts
+//! the typed [`ChessConfig`] wrapper directly.
+//!
+//! The Rust source-of-truth structs in `chess-corners` /
+//! `chess-corners-core` are unchanged; only the binding layer adds
+//! these wrappers, preserving the workspace dependency rule that
+//! core crates do not depend on `pyo3`.
+
+use std::collections::BTreeSet;
+
+use chess_corners::{
+    CenterOfMassConfig as RsCenterOfMassConfig, ChessConfig as RsChessConfig,
+    DescriptorMode as RsDescriptorMode, DetectorMode as RsDetectorMode,
+    ForstnerConfig as RsForstnerConfig, PeakFitMode as RsPeakFitMode,
+    RadonDetectorParams as RsRadonDetectorParams, RadonPeakConfig as RsRadonPeakConfig,
+    RefinementMethod as RsRefinementMethod, RefinerConfig as RsRefinerConfig,
+    SaddlePointConfig as RsSaddlePointConfig, ThresholdMode as RsThresholdMode,
+};
+use pyo3::create_exception;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::types::{PyBool, PyDict, PyFloat, PyInt, PyString, PyType};
+
+create_exception!(_native, ConfigError, PyValueError);
+
+// ---------------------------------------------------------------------------
+// Helpers for dict → field deserialization with unknown-key rejection.
+// ---------------------------------------------------------------------------
+
+fn config_error(msg: impl Into<String>) -> PyErr {
+    ConfigError::new_err(msg.into())
+}
+
+fn require_dict<'py>(value: &Bound<'py, PyAny>, path: &str) -> PyResult<Bound<'py, PyDict>> {
+    value
+        .cast::<PyDict>()
+        .cloned()
+        .map_err(|_| config_error(format!("{path} must be an object")))
+}
+
+fn reject_unknown_keys(dict: &Bound<'_, PyDict>, allowed: &[&str], path: &str) -> PyResult<()> {
+    let allowed: BTreeSet<&str> = allowed.iter().copied().collect();
+    let mut unknown: Vec<String> = Vec::new();
+    for key in dict.keys().iter() {
+        let s: String = key.extract()?;
+        if !allowed.contains(s.as_str()) {
+            unknown.push(s);
+        }
+    }
+    if !unknown.is_empty() {
+        unknown.sort();
+        return Err(config_error(format!(
+            "{path} has unknown keys: {}",
+            unknown.join(", ")
+        )));
+    }
+    Ok(())
+}
+
+fn extract_int(dict: &Bound<'_, PyDict>, key: &str, path: &str) -> PyResult<Option<i64>> {
+    let Some(value) = dict.get_item(key)? else {
+        return Ok(None);
+    };
+    if value.is_instance_of::<PyBool>() || !value.is_instance_of::<PyInt>() {
+        return Err(config_error(format!("{path}.{key} must be an integer")));
+    }
+    Ok(Some(value.extract::<i64>()?))
+}
+
+fn extract_float(dict: &Bound<'_, PyDict>, key: &str, path: &str) -> PyResult<Option<f64>> {
+    let Some(value) = dict.get_item(key)? else {
+        return Ok(None);
+    };
+    if value.is_instance_of::<PyBool>()
+        || !(value.is_instance_of::<PyFloat>() || value.is_instance_of::<PyInt>())
+    {
+        return Err(config_error(format!("{path}.{key} must be a number")));
+    }
+    Ok(Some(value.extract::<f64>()?))
+}
+
+fn extract_string(dict: &Bound<'_, PyDict>, key: &str, path: &str) -> PyResult<Option<String>> {
+    let Some(value) = dict.get_item(key)? else {
+        return Ok(None);
+    };
+    if !value.is_instance_of::<PyString>() {
+        return Err(config_error(format!("{path}.{key} must be a string")));
+    }
+    Ok(Some(value.extract::<String>()?))
+}
+
+// ---------------------------------------------------------------------------
+// Enums.
+// ---------------------------------------------------------------------------
+
+macro_rules! py_enum {
+    (
+        $(#[$attr:meta])*
+        $name:ident, $rs:path,
+        [$( ($variant:ident, $py_name:literal, $rs_variant:ident) ),+ $(,)?]
+    ) => {
+        $(#[$attr])*
+        #[pyclass(eq, eq_int, module = "chess_corners", from_py_object)]
+        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+        pub enum $name {
+            $(
+                #[pyo3(name = $py_name)]
+                $variant,
+            )+
+        }
+
+        impl From<$name> for $rs {
+            fn from(v: $name) -> Self {
+                match v {
+                    $( $name::$variant => <$rs>::$rs_variant, )+
+                }
+            }
+        }
+
+        impl From<$rs> for $name {
+            #[allow(unreachable_patterns)]
+            fn from(v: $rs) -> Self {
+                match v {
+                    $( <$rs>::$rs_variant => $name::$variant, )+
+                    // Future-proof for `#[non_exhaustive]` source enums.
+                    _ => $name::default_for_unknown(),
+                }
+            }
+        }
+
+        impl $name {
+            fn default_for_unknown() -> Self {
+                Self::__first()
+            }
+            fn __first() -> Self {
+                #[allow(unreachable_code, clippy::needless_return)]
+                {
+                    $( return $name::$variant; )+
+                }
+            }
+        }
+    };
+}
+
+py_enum!(
+    /// Detector kernel selection.
+    DetectorMode, RsDetectorMode,
+    [
+        (Canonical, "CANONICAL", Canonical),
+        (Broad, "BROAD", Broad),
+        (Radon, "RADON", Radon),
+    ]
+);
+
+py_enum!(
+    /// Descriptor sampling override.
+    DescriptorMode, RsDescriptorMode,
+    [
+        (FollowDetector, "FOLLOW_DETECTOR", FollowDetector),
+        (Canonical, "CANONICAL", Canonical),
+        (Broad, "BROAD", Broad),
+    ]
+);
+
+py_enum!(
+    /// Threshold interpretation for candidate selection.
+    ThresholdMode, RsThresholdMode,
+    [
+        (Relative, "RELATIVE", Relative),
+        (Absolute, "ABSOLUTE", Absolute),
+    ]
+);
+
+py_enum!(
+    /// Subpixel refinement algorithm applied to each candidate.
+    RefinementMethod, RsRefinementMethod,
+    [
+        (CenterOfMass, "CENTER_OF_MASS", CenterOfMass),
+        (Forstner, "FORSTNER", Forstner),
+        (SaddlePoint, "SADDLE_POINT", SaddlePoint),
+        (RadonPeak, "RADON_PEAK", RadonPeak),
+    ]
+);
+
+py_enum!(
+    /// Subpixel peak-fit mode used by the Radon refiner and detector.
+    PeakFitMode, RsPeakFitMode,
+    [
+        (Parabolic, "PARABOLIC", Parabolic),
+        (Gaussian, "GAUSSIAN", Gaussian),
+    ]
+);
+
+fn parse_enum<E>(value: &str, path: &str, allowed: &[(&str, E)]) -> PyResult<E>
+where
+    E: Copy,
+{
+    for (name, variant) in allowed {
+        if *name == value {
+            return Ok(*variant);
+        }
+    }
+    let allowed_str = allowed
+        .iter()
+        .map(|(n, _)| *n)
+        .collect::<Vec<_>>()
+        .join(", ");
+    Err(config_error(format!(
+        "{path} must be one of: {allowed_str}"
+    )))
+}
+
+fn parse_detector_mode(value: &str, path: &str) -> PyResult<RsDetectorMode> {
+    parse_enum(
+        value,
+        path,
+        &[
+            ("canonical", RsDetectorMode::Canonical),
+            ("broad", RsDetectorMode::Broad),
+            ("radon", RsDetectorMode::Radon),
+        ],
+    )
+}
+
+fn parse_descriptor_mode(value: &str, path: &str) -> PyResult<RsDescriptorMode> {
+    parse_enum(
+        value,
+        path,
+        &[
+            ("follow_detector", RsDescriptorMode::FollowDetector),
+            ("canonical", RsDescriptorMode::Canonical),
+            ("broad", RsDescriptorMode::Broad),
+        ],
+    )
+}
+
+fn parse_threshold_mode(value: &str, path: &str) -> PyResult<RsThresholdMode> {
+    parse_enum(
+        value,
+        path,
+        &[
+            ("relative", RsThresholdMode::Relative),
+            ("absolute", RsThresholdMode::Absolute),
+        ],
+    )
+}
+
+fn parse_refinement_method(value: &str, path: &str) -> PyResult<RsRefinementMethod> {
+    parse_enum(
+        value,
+        path,
+        &[
+            ("center_of_mass", RsRefinementMethod::CenterOfMass),
+            ("forstner", RsRefinementMethod::Forstner),
+            ("saddle_point", RsRefinementMethod::SaddlePoint),
+            ("radon_peak", RsRefinementMethod::RadonPeak),
+        ],
+    )
+}
+
+fn parse_peak_fit_mode(value: &str, path: &str) -> PyResult<RsPeakFitMode> {
+    parse_enum(
+        value,
+        path,
+        &[
+            ("parabolic", RsPeakFitMode::Parabolic),
+            ("gaussian", RsPeakFitMode::Gaussian),
+        ],
+    )
+}
+
+fn detector_mode_str(v: RsDetectorMode) -> &'static str {
+    match v {
+        RsDetectorMode::Canonical => "canonical",
+        RsDetectorMode::Broad => "broad",
+        RsDetectorMode::Radon => "radon",
+    }
+}
+
+fn descriptor_mode_str(v: RsDescriptorMode) -> &'static str {
+    match v {
+        RsDescriptorMode::FollowDetector => "follow_detector",
+        RsDescriptorMode::Canonical => "canonical",
+        RsDescriptorMode::Broad => "broad",
+    }
+}
+
+fn threshold_mode_str(v: RsThresholdMode) -> &'static str {
+    match v {
+        RsThresholdMode::Relative => "relative",
+        RsThresholdMode::Absolute => "absolute",
+    }
+}
+
+fn refinement_method_str(v: RsRefinementMethod) -> &'static str {
+    match v {
+        RsRefinementMethod::CenterOfMass => "center_of_mass",
+        RsRefinementMethod::Forstner => "forstner",
+        RsRefinementMethod::SaddlePoint => "saddle_point",
+        RsRefinementMethod::RadonPeak => "radon_peak",
+    }
+}
+
+fn peak_fit_mode_str(v: RsPeakFitMode) -> &'static str {
+    match v {
+        RsPeakFitMode::Parabolic => "parabolic",
+        RsPeakFitMode::Gaussian => "gaussian",
+        _ => "gaussian",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared dict / json / pretty / print methods.
+// ---------------------------------------------------------------------------
+
+fn json_dumps(
+    py: Python<'_>,
+    obj: &Bound<'_, PyAny>,
+    indent: Option<i64>,
+    sort_keys: bool,
+) -> PyResult<String> {
+    let json = py.import("json")?;
+    let kwargs = PyDict::new(py);
+    if let Some(i) = indent {
+        kwargs.set_item("indent", i)?;
+    }
+    kwargs.set_item("sort_keys", sort_keys)?;
+    let result = json.call_method("dumps", (obj,), Some(&kwargs))?;
+    result.extract::<String>()
+}
+
+fn json_loads<'py>(py: Python<'py>, text: &str) -> PyResult<Bound<'py, PyAny>> {
+    let json = py.import("json")?;
+    json.call_method1("loads", (text,))
+}
+
+// ---------------------------------------------------------------------------
+// CenterOfMassConfig
+// ---------------------------------------------------------------------------
+
+#[pyclass(module = "chess_corners", skip_from_py_object)]
+#[derive(Clone, Debug)]
+pub struct CenterOfMassConfig {
+    pub(crate) inner: RsCenterOfMassConfig,
+}
+
+#[pymethods]
+impl CenterOfMassConfig {
+    #[new]
+    fn new() -> Self {
+        Self {
+            inner: RsCenterOfMassConfig::default(),
+        }
+    }
+
+    #[getter]
+    fn radius(&self) -> i32 {
+        self.inner.radius
+    }
+    #[setter]
+    fn set_radius(&mut self, v: i32) {
+        self.inner.radius = v;
+    }
+
+    fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyDict>> {
+        let d = PyDict::new(py);
+        d.set_item("radius", self.inner.radius)?;
+        Ok(d.unbind())
+    }
+
+    #[classmethod]
+    fn from_dict(_cls: &Bound<'_, PyType>, data: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let dict = require_dict(data, "center_of_mass")?;
+        reject_unknown_keys(&dict, &["radius"], "center_of_mass")?;
+        let mut cfg = Self::new();
+        if let Some(v) = extract_int(&dict, "radius", "center_of_mass")? {
+            cfg.inner.radius = v as i32;
+        }
+        Ok(cfg)
+    }
+
+    #[pyo3(signature = (*, indent=None, sort_keys=true))]
+    fn to_json(&self, py: Python<'_>, indent: Option<i64>, sort_keys: bool) -> PyResult<String> {
+        let dict = self.to_dict(py)?;
+        json_dumps(py, dict.bind(py), indent, sort_keys)
+    }
+
+    #[classmethod]
+    fn from_json(cls: &Bound<'_, PyType>, py: Python<'_>, text: &str) -> PyResult<Self> {
+        let value = json_loads(py, text)
+            .map_err(|e| config_error(format!("failed to parse config JSON: {e}")))?;
+        Self::from_dict(cls, &value)
+    }
+
+    #[pyo3(signature = (*, indent=2, sort_keys=true))]
+    fn pretty(&self, py: Python<'_>, indent: i64, sort_keys: bool) -> PyResult<String> {
+        self.to_json(py, Some(indent), sort_keys)
+    }
+
+    fn __repr__(&self, py: Python<'_>) -> PyResult<String> {
+        self.pretty(py, 2, true)
+    }
+    fn __str__(&self, py: Python<'_>) -> PyResult<String> {
+        self.pretty(py, 2, true)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ForstnerConfig
+// ---------------------------------------------------------------------------
+
+#[pyclass(module = "chess_corners", skip_from_py_object)]
+#[derive(Clone, Debug)]
+pub struct ForstnerConfig {
+    pub(crate) inner: RsForstnerConfig,
+}
+
+#[pymethods]
+impl ForstnerConfig {
+    #[new]
+    fn new() -> Self {
+        Self {
+            inner: RsForstnerConfig::default(),
+        }
+    }
+
+    #[getter]
+    fn radius(&self) -> i32 {
+        self.inner.radius
+    }
+    #[setter]
+    fn set_radius(&mut self, v: i32) {
+        self.inner.radius = v;
+    }
+
+    #[getter]
+    fn min_trace(&self) -> f32 {
+        self.inner.min_trace
+    }
+    #[setter]
+    fn set_min_trace(&mut self, v: f32) {
+        self.inner.min_trace = v;
+    }
+
+    #[getter]
+    fn min_det(&self) -> f32 {
+        self.inner.min_det
+    }
+    #[setter]
+    fn set_min_det(&mut self, v: f32) {
+        self.inner.min_det = v;
+    }
+
+    #[getter]
+    fn max_condition_number(&self) -> f32 {
+        self.inner.max_condition_number
+    }
+    #[setter]
+    fn set_max_condition_number(&mut self, v: f32) {
+        self.inner.max_condition_number = v;
+    }
+
+    #[getter]
+    fn max_offset(&self) -> f32 {
+        self.inner.max_offset
+    }
+    #[setter]
+    fn set_max_offset(&mut self, v: f32) {
+        self.inner.max_offset = v;
+    }
+
+    fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyDict>> {
+        let d = PyDict::new(py);
+        d.set_item("radius", self.inner.radius)?;
+        d.set_item("min_trace", self.inner.min_trace as f64)?;
+        d.set_item("min_det", self.inner.min_det as f64)?;
+        d.set_item(
+            "max_condition_number",
+            self.inner.max_condition_number as f64,
+        )?;
+        d.set_item("max_offset", self.inner.max_offset as f64)?;
+        Ok(d.unbind())
+    }
+
+    #[classmethod]
+    fn from_dict(_cls: &Bound<'_, PyType>, data: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let dict = require_dict(data, "forstner")?;
+        reject_unknown_keys(
+            &dict,
+            &[
+                "radius",
+                "min_trace",
+                "min_det",
+                "max_condition_number",
+                "max_offset",
+            ],
+            "forstner",
+        )?;
+        let mut cfg = Self::new();
+        if let Some(v) = extract_int(&dict, "radius", "forstner")? {
+            cfg.inner.radius = v as i32;
+        }
+        if let Some(v) = extract_float(&dict, "min_trace", "forstner")? {
+            cfg.inner.min_trace = v as f32;
+        }
+        if let Some(v) = extract_float(&dict, "min_det", "forstner")? {
+            cfg.inner.min_det = v as f32;
+        }
+        if let Some(v) = extract_float(&dict, "max_condition_number", "forstner")? {
+            cfg.inner.max_condition_number = v as f32;
+        }
+        if let Some(v) = extract_float(&dict, "max_offset", "forstner")? {
+            cfg.inner.max_offset = v as f32;
+        }
+        Ok(cfg)
+    }
+
+    #[pyo3(signature = (*, indent=None, sort_keys=true))]
+    fn to_json(&self, py: Python<'_>, indent: Option<i64>, sort_keys: bool) -> PyResult<String> {
+        let dict = self.to_dict(py)?;
+        json_dumps(py, dict.bind(py), indent, sort_keys)
+    }
+
+    #[classmethod]
+    fn from_json(cls: &Bound<'_, PyType>, py: Python<'_>, text: &str) -> PyResult<Self> {
+        let value = json_loads(py, text)
+            .map_err(|e| config_error(format!("failed to parse config JSON: {e}")))?;
+        Self::from_dict(cls, &value)
+    }
+
+    #[pyo3(signature = (*, indent=2, sort_keys=true))]
+    fn pretty(&self, py: Python<'_>, indent: i64, sort_keys: bool) -> PyResult<String> {
+        self.to_json(py, Some(indent), sort_keys)
+    }
+
+    fn __repr__(&self, py: Python<'_>) -> PyResult<String> {
+        self.pretty(py, 2, true)
+    }
+    fn __str__(&self, py: Python<'_>) -> PyResult<String> {
+        self.pretty(py, 2, true)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SaddlePointConfig
+// ---------------------------------------------------------------------------
+
+#[pyclass(module = "chess_corners", skip_from_py_object)]
+#[derive(Clone, Debug)]
+pub struct SaddlePointConfig {
+    pub(crate) inner: RsSaddlePointConfig,
+}
+
+#[pymethods]
+impl SaddlePointConfig {
+    #[new]
+    fn new() -> Self {
+        Self {
+            inner: RsSaddlePointConfig::default(),
+        }
+    }
+
+    #[getter]
+    fn radius(&self) -> i32 {
+        self.inner.radius
+    }
+    #[setter]
+    fn set_radius(&mut self, v: i32) {
+        self.inner.radius = v;
+    }
+
+    #[getter]
+    fn det_margin(&self) -> f32 {
+        self.inner.det_margin
+    }
+    #[setter]
+    fn set_det_margin(&mut self, v: f32) {
+        self.inner.det_margin = v;
+    }
+
+    #[getter]
+    fn max_offset(&self) -> f32 {
+        self.inner.max_offset
+    }
+    #[setter]
+    fn set_max_offset(&mut self, v: f32) {
+        self.inner.max_offset = v;
+    }
+
+    #[getter]
+    fn min_abs_det(&self) -> f32 {
+        self.inner.min_abs_det
+    }
+    #[setter]
+    fn set_min_abs_det(&mut self, v: f32) {
+        self.inner.min_abs_det = v;
+    }
+
+    fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyDict>> {
+        let d = PyDict::new(py);
+        d.set_item("radius", self.inner.radius)?;
+        d.set_item("det_margin", self.inner.det_margin as f64)?;
+        d.set_item("max_offset", self.inner.max_offset as f64)?;
+        d.set_item("min_abs_det", self.inner.min_abs_det as f64)?;
+        Ok(d.unbind())
+    }
+
+    #[classmethod]
+    fn from_dict(_cls: &Bound<'_, PyType>, data: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let dict = require_dict(data, "saddle_point")?;
+        reject_unknown_keys(
+            &dict,
+            &["radius", "det_margin", "max_offset", "min_abs_det"],
+            "saddle_point",
+        )?;
+        let mut cfg = Self::new();
+        if let Some(v) = extract_int(&dict, "radius", "saddle_point")? {
+            cfg.inner.radius = v as i32;
+        }
+        if let Some(v) = extract_float(&dict, "det_margin", "saddle_point")? {
+            cfg.inner.det_margin = v as f32;
+        }
+        if let Some(v) = extract_float(&dict, "max_offset", "saddle_point")? {
+            cfg.inner.max_offset = v as f32;
+        }
+        if let Some(v) = extract_float(&dict, "min_abs_det", "saddle_point")? {
+            cfg.inner.min_abs_det = v as f32;
+        }
+        Ok(cfg)
+    }
+
+    #[pyo3(signature = (*, indent=None, sort_keys=true))]
+    fn to_json(&self, py: Python<'_>, indent: Option<i64>, sort_keys: bool) -> PyResult<String> {
+        let dict = self.to_dict(py)?;
+        json_dumps(py, dict.bind(py), indent, sort_keys)
+    }
+
+    #[classmethod]
+    fn from_json(cls: &Bound<'_, PyType>, py: Python<'_>, text: &str) -> PyResult<Self> {
+        let value = json_loads(py, text)
+            .map_err(|e| config_error(format!("failed to parse config JSON: {e}")))?;
+        Self::from_dict(cls, &value)
+    }
+
+    #[pyo3(signature = (*, indent=2, sort_keys=true))]
+    fn pretty(&self, py: Python<'_>, indent: i64, sort_keys: bool) -> PyResult<String> {
+        self.to_json(py, Some(indent), sort_keys)
+    }
+
+    fn __repr__(&self, py: Python<'_>) -> PyResult<String> {
+        self.pretty(py, 2, true)
+    }
+    fn __str__(&self, py: Python<'_>) -> PyResult<String> {
+        self.pretty(py, 2, true)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RadonPeakConfig
+// ---------------------------------------------------------------------------
+
+#[pyclass(module = "chess_corners", skip_from_py_object)]
+#[derive(Clone, Debug)]
+pub struct RadonPeakConfig {
+    pub(crate) inner: RsRadonPeakConfig,
+}
+
+#[pymethods]
+impl RadonPeakConfig {
+    #[new]
+    fn new() -> Self {
+        Self {
+            inner: RsRadonPeakConfig::default(),
+        }
+    }
+
+    #[getter]
+    fn ray_radius(&self) -> u32 {
+        self.inner.ray_radius
+    }
+    #[setter]
+    fn set_ray_radius(&mut self, v: u32) {
+        self.inner.ray_radius = v;
+    }
+
+    #[getter]
+    fn patch_radius(&self) -> u32 {
+        self.inner.patch_radius
+    }
+    #[setter]
+    fn set_patch_radius(&mut self, v: u32) {
+        self.inner.patch_radius = v;
+    }
+
+    #[getter]
+    fn image_upsample(&self) -> u32 {
+        self.inner.image_upsample
+    }
+    #[setter]
+    fn set_image_upsample(&mut self, v: u32) {
+        self.inner.image_upsample = v;
+    }
+
+    #[getter]
+    fn response_blur_radius(&self) -> u32 {
+        self.inner.response_blur_radius
+    }
+    #[setter]
+    fn set_response_blur_radius(&mut self, v: u32) {
+        self.inner.response_blur_radius = v;
+    }
+
+    #[getter]
+    fn peak_fit(&self) -> PeakFitMode {
+        self.inner.peak_fit.into()
+    }
+    #[setter]
+    fn set_peak_fit(&mut self, v: PeakFitMode) {
+        self.inner.peak_fit = v.into();
+    }
+
+    #[getter]
+    fn min_response(&self) -> f32 {
+        self.inner.min_response
+    }
+    #[setter]
+    fn set_min_response(&mut self, v: f32) {
+        self.inner.min_response = v;
+    }
+
+    #[getter]
+    fn max_offset(&self) -> f32 {
+        self.inner.max_offset
+    }
+    #[setter]
+    fn set_max_offset(&mut self, v: f32) {
+        self.inner.max_offset = v;
+    }
+
+    fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyDict>> {
+        let d = PyDict::new(py);
+        d.set_item("ray_radius", self.inner.ray_radius)?;
+        d.set_item("patch_radius", self.inner.patch_radius)?;
+        d.set_item("image_upsample", self.inner.image_upsample)?;
+        d.set_item("response_blur_radius", self.inner.response_blur_radius)?;
+        d.set_item("peak_fit", peak_fit_mode_str(self.inner.peak_fit))?;
+        d.set_item("min_response", self.inner.min_response as f64)?;
+        d.set_item("max_offset", self.inner.max_offset as f64)?;
+        Ok(d.unbind())
+    }
+
+    #[classmethod]
+    fn from_dict(_cls: &Bound<'_, PyType>, data: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let dict = require_dict(data, "radon_peak")?;
+        reject_unknown_keys(
+            &dict,
+            &[
+                "ray_radius",
+                "patch_radius",
+                "image_upsample",
+                "response_blur_radius",
+                "peak_fit",
+                "min_response",
+                "max_offset",
+            ],
+            "radon_peak",
+        )?;
+        let mut cfg = Self::new();
+        if let Some(v) = extract_int(&dict, "ray_radius", "radon_peak")? {
+            cfg.inner.ray_radius = v as u32;
+        }
+        if let Some(v) = extract_int(&dict, "patch_radius", "radon_peak")? {
+            cfg.inner.patch_radius = v as u32;
+        }
+        if let Some(v) = extract_int(&dict, "image_upsample", "radon_peak")? {
+            cfg.inner.image_upsample = v as u32;
+        }
+        if let Some(v) = extract_int(&dict, "response_blur_radius", "radon_peak")? {
+            cfg.inner.response_blur_radius = v as u32;
+        }
+        if let Some(s) = extract_string(&dict, "peak_fit", "radon_peak")? {
+            cfg.inner.peak_fit = parse_peak_fit_mode(&s, "radon_peak.peak_fit")?;
+        }
+        if let Some(v) = extract_float(&dict, "min_response", "radon_peak")? {
+            cfg.inner.min_response = v as f32;
+        }
+        if let Some(v) = extract_float(&dict, "max_offset", "radon_peak")? {
+            cfg.inner.max_offset = v as f32;
+        }
+        Ok(cfg)
+    }
+
+    #[pyo3(signature = (*, indent=None, sort_keys=true))]
+    fn to_json(&self, py: Python<'_>, indent: Option<i64>, sort_keys: bool) -> PyResult<String> {
+        let dict = self.to_dict(py)?;
+        json_dumps(py, dict.bind(py), indent, sort_keys)
+    }
+
+    #[classmethod]
+    fn from_json(cls: &Bound<'_, PyType>, py: Python<'_>, text: &str) -> PyResult<Self> {
+        let value = json_loads(py, text)
+            .map_err(|e| config_error(format!("failed to parse config JSON: {e}")))?;
+        Self::from_dict(cls, &value)
+    }
+
+    #[pyo3(signature = (*, indent=2, sort_keys=true))]
+    fn pretty(&self, py: Python<'_>, indent: i64, sort_keys: bool) -> PyResult<String> {
+        self.to_json(py, Some(indent), sort_keys)
+    }
+
+    fn __repr__(&self, py: Python<'_>) -> PyResult<String> {
+        self.pretty(py, 2, true)
+    }
+    fn __str__(&self, py: Python<'_>) -> PyResult<String> {
+        self.pretty(py, 2, true)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RadonDetectorParams
+// ---------------------------------------------------------------------------
+
+#[pyclass(module = "chess_corners", skip_from_py_object)]
+#[derive(Clone, Debug)]
+pub struct RadonDetectorParams {
+    pub(crate) inner: RsRadonDetectorParams,
+}
+
+#[pymethods]
+impl RadonDetectorParams {
+    #[new]
+    fn new() -> Self {
+        Self {
+            inner: RsRadonDetectorParams::default(),
+        }
+    }
+
+    #[getter]
+    fn ray_radius(&self) -> u32 {
+        self.inner.ray_radius
+    }
+    #[setter]
+    fn set_ray_radius(&mut self, v: u32) {
+        self.inner.ray_radius = v;
+    }
+
+    #[getter]
+    fn image_upsample(&self) -> u32 {
+        self.inner.image_upsample
+    }
+    #[setter]
+    fn set_image_upsample(&mut self, v: u32) {
+        self.inner.image_upsample = v;
+    }
+
+    #[getter]
+    fn response_blur_radius(&self) -> u32 {
+        self.inner.response_blur_radius
+    }
+    #[setter]
+    fn set_response_blur_radius(&mut self, v: u32) {
+        self.inner.response_blur_radius = v;
+    }
+
+    #[getter]
+    fn peak_fit(&self) -> PeakFitMode {
+        self.inner.peak_fit.into()
+    }
+    #[setter]
+    fn set_peak_fit(&mut self, v: PeakFitMode) {
+        self.inner.peak_fit = v.into();
+    }
+
+    #[getter]
+    fn threshold_rel(&self) -> f32 {
+        self.inner.threshold_rel
+    }
+    #[setter]
+    fn set_threshold_rel(&mut self, v: f32) {
+        self.inner.threshold_rel = v;
+    }
+
+    #[getter]
+    fn threshold_abs(&self) -> Option<f32> {
+        self.inner.threshold_abs
+    }
+    #[setter]
+    fn set_threshold_abs(&mut self, v: Option<f32>) {
+        self.inner.threshold_abs = v;
+    }
+
+    #[getter]
+    fn nms_radius(&self) -> u32 {
+        self.inner.nms_radius
+    }
+    #[setter]
+    fn set_nms_radius(&mut self, v: u32) {
+        self.inner.nms_radius = v;
+    }
+
+    #[getter]
+    fn min_cluster_size(&self) -> u32 {
+        self.inner.min_cluster_size
+    }
+    #[setter]
+    fn set_min_cluster_size(&mut self, v: u32) {
+        self.inner.min_cluster_size = v;
+    }
+
+    fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyDict>> {
+        let d = PyDict::new(py);
+        d.set_item("ray_radius", self.inner.ray_radius)?;
+        d.set_item("image_upsample", self.inner.image_upsample)?;
+        d.set_item("response_blur_radius", self.inner.response_blur_radius)?;
+        d.set_item("peak_fit", peak_fit_mode_str(self.inner.peak_fit))?;
+        d.set_item("threshold_rel", self.inner.threshold_rel as f64)?;
+        d.set_item("threshold_abs", self.inner.threshold_abs.map(|x| x as f64))?;
+        d.set_item("nms_radius", self.inner.nms_radius)?;
+        d.set_item("min_cluster_size", self.inner.min_cluster_size)?;
+        Ok(d.unbind())
+    }
+
+    #[classmethod]
+    fn from_dict(_cls: &Bound<'_, PyType>, data: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let dict = require_dict(data, "radon_detector")?;
+        reject_unknown_keys(
+            &dict,
+            &[
+                "ray_radius",
+                "image_upsample",
+                "response_blur_radius",
+                "peak_fit",
+                "threshold_rel",
+                "threshold_abs",
+                "nms_radius",
+                "min_cluster_size",
+            ],
+            "radon_detector",
+        )?;
+        let mut cfg = Self::new();
+        if let Some(v) = extract_int(&dict, "ray_radius", "radon_detector")? {
+            cfg.inner.ray_radius = v as u32;
+        }
+        if let Some(v) = extract_int(&dict, "image_upsample", "radon_detector")? {
+            cfg.inner.image_upsample = v as u32;
+        }
+        if let Some(v) = extract_int(&dict, "response_blur_radius", "radon_detector")? {
+            cfg.inner.response_blur_radius = v as u32;
+        }
+        if let Some(s) = extract_string(&dict, "peak_fit", "radon_detector")? {
+            cfg.inner.peak_fit = parse_peak_fit_mode(&s, "radon_detector.peak_fit")?;
+        }
+        if let Some(v) = extract_float(&dict, "threshold_rel", "radon_detector")? {
+            cfg.inner.threshold_rel = v as f32;
+        }
+        if let Some(value) = dict.get_item("threshold_abs")? {
+            if value.is_none() {
+                cfg.inner.threshold_abs = None;
+            } else if value.is_instance_of::<PyBool>()
+                || !(value.is_instance_of::<PyFloat>() || value.is_instance_of::<PyInt>())
+            {
+                return Err(config_error(
+                    "radon_detector.threshold_abs must be a number or null",
+                ));
+            } else {
+                cfg.inner.threshold_abs = Some(value.extract::<f64>()? as f32);
+            }
+        }
+        if let Some(v) = extract_int(&dict, "nms_radius", "radon_detector")? {
+            cfg.inner.nms_radius = v as u32;
+        }
+        if let Some(v) = extract_int(&dict, "min_cluster_size", "radon_detector")? {
+            cfg.inner.min_cluster_size = v as u32;
+        }
+        Ok(cfg)
+    }
+
+    #[pyo3(signature = (*, indent=None, sort_keys=true))]
+    fn to_json(&self, py: Python<'_>, indent: Option<i64>, sort_keys: bool) -> PyResult<String> {
+        let dict = self.to_dict(py)?;
+        json_dumps(py, dict.bind(py), indent, sort_keys)
+    }
+
+    #[classmethod]
+    fn from_json(cls: &Bound<'_, PyType>, py: Python<'_>, text: &str) -> PyResult<Self> {
+        let value = json_loads(py, text)
+            .map_err(|e| config_error(format!("failed to parse config JSON: {e}")))?;
+        Self::from_dict(cls, &value)
+    }
+
+    #[pyo3(signature = (*, indent=2, sort_keys=true))]
+    fn pretty(&self, py: Python<'_>, indent: i64, sort_keys: bool) -> PyResult<String> {
+        self.to_json(py, Some(indent), sort_keys)
+    }
+
+    fn __repr__(&self, py: Python<'_>) -> PyResult<String> {
+        self.pretty(py, 2, true)
+    }
+    fn __str__(&self, py: Python<'_>) -> PyResult<String> {
+        self.pretty(py, 2, true)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RefinerConfig
+// ---------------------------------------------------------------------------
+
+#[pyclass(module = "chess_corners")]
+pub struct RefinerConfig {
+    /// `kind` is stored on the inner Rust value because it's a scalar
+    /// enum. Per-variant configs are stored as Python objects so that
+    /// chained mutation (`cfg.refiner.forstner.max_offset = 2.0`)
+    /// behaves like real reference semantics — the same Python
+    /// object is returned by every getter call.
+    pub(crate) kind: RsRefinementMethod,
+    pub(crate) center_of_mass: Py<CenterOfMassConfig>,
+    pub(crate) forstner: Py<ForstnerConfig>,
+    pub(crate) saddle_point: Py<SaddlePointConfig>,
+    pub(crate) radon_peak: Py<RadonPeakConfig>,
+}
+
+impl RefinerConfig {
+    pub(crate) fn build(py: Python<'_>) -> PyResult<Self> {
+        Ok(Self {
+            kind: RsRefinementMethod::default(),
+            center_of_mass: Py::new(py, CenterOfMassConfig::new())?,
+            forstner: Py::new(py, ForstnerConfig::new())?,
+            saddle_point: Py::new(py, SaddlePointConfig::new())?,
+            radon_peak: Py::new(py, RadonPeakConfig::new())?,
+        })
+    }
+
+    pub(crate) fn to_inner(&self, py: Python<'_>) -> RsRefinerConfig {
+        RsRefinerConfig {
+            kind: self.kind,
+            center_of_mass: self.center_of_mass.borrow(py).inner,
+            forstner: self.forstner.borrow(py).inner,
+            saddle_point: self.saddle_point.borrow(py).inner,
+            radon_peak: self.radon_peak.borrow(py).inner,
+        }
+    }
+}
+
+#[pymethods]
+impl RefinerConfig {
+    #[new]
+    fn py_new(py: Python<'_>) -> PyResult<Self> {
+        Self::build(py)
+    }
+
+    #[classmethod]
+    #[pyo3(name = "center_of_mass_config")]
+    fn center_of_mass_config(_cls: &Bound<'_, PyType>, py: Python<'_>) -> PyResult<Self> {
+        let mut cfg = Self::build(py)?;
+        cfg.kind = RsRefinementMethod::CenterOfMass;
+        Ok(cfg)
+    }
+    #[classmethod]
+    #[pyo3(name = "forstner_config")]
+    fn forstner_config(_cls: &Bound<'_, PyType>, py: Python<'_>) -> PyResult<Self> {
+        let mut cfg = Self::build(py)?;
+        cfg.kind = RsRefinementMethod::Forstner;
+        Ok(cfg)
+    }
+    #[classmethod]
+    #[pyo3(name = "saddle_point_config")]
+    fn saddle_point_config(_cls: &Bound<'_, PyType>, py: Python<'_>) -> PyResult<Self> {
+        let mut cfg = Self::build(py)?;
+        cfg.kind = RsRefinementMethod::SaddlePoint;
+        Ok(cfg)
+    }
+    #[classmethod]
+    #[pyo3(name = "radon_peak_config")]
+    fn radon_peak_config(_cls: &Bound<'_, PyType>, py: Python<'_>) -> PyResult<Self> {
+        let mut cfg = Self::build(py)?;
+        cfg.kind = RsRefinementMethod::RadonPeak;
+        Ok(cfg)
+    }
+
+    #[getter]
+    fn kind(&self) -> RefinementMethod {
+        self.kind.into()
+    }
+    #[setter]
+    fn set_kind(&mut self, v: RefinementMethod) {
+        self.kind = v.into();
+    }
+
+    #[getter]
+    fn center_of_mass(&self, py: Python<'_>) -> Py<CenterOfMassConfig> {
+        self.center_of_mass.clone_ref(py)
+    }
+    #[setter]
+    fn set_center_of_mass(&mut self, v: Py<CenterOfMassConfig>) {
+        self.center_of_mass = v;
+    }
+
+    #[getter]
+    fn forstner(&self, py: Python<'_>) -> Py<ForstnerConfig> {
+        self.forstner.clone_ref(py)
+    }
+    #[setter]
+    fn set_forstner(&mut self, v: Py<ForstnerConfig>) {
+        self.forstner = v;
+    }
+
+    #[getter]
+    fn saddle_point(&self, py: Python<'_>) -> Py<SaddlePointConfig> {
+        self.saddle_point.clone_ref(py)
+    }
+    #[setter]
+    fn set_saddle_point(&mut self, v: Py<SaddlePointConfig>) {
+        self.saddle_point = v;
+    }
+
+    #[getter]
+    fn radon_peak(&self, py: Python<'_>) -> Py<RadonPeakConfig> {
+        self.radon_peak.clone_ref(py)
+    }
+    #[setter]
+    fn set_radon_peak(&mut self, v: Py<RadonPeakConfig>) {
+        self.radon_peak = v;
+    }
+
+    fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyDict>> {
+        let d = PyDict::new(py);
+        d.set_item("kind", refinement_method_str(self.kind))?;
+        d.set_item(
+            "center_of_mass",
+            self.center_of_mass.borrow(py).to_dict(py)?,
+        )?;
+        d.set_item("forstner", self.forstner.borrow(py).to_dict(py)?)?;
+        d.set_item("saddle_point", self.saddle_point.borrow(py).to_dict(py)?)?;
+        d.set_item("radon_peak", self.radon_peak.borrow(py).to_dict(py)?)?;
+        Ok(d.unbind())
+    }
+
+    #[classmethod]
+    fn from_dict(
+        _cls: &Bound<'_, PyType>,
+        py: Python<'_>,
+        data: &Bound<'_, PyAny>,
+    ) -> PyResult<Self> {
+        let dict = require_dict(data, "refiner")?;
+        reject_unknown_keys(
+            &dict,
+            &[
+                "kind",
+                "center_of_mass",
+                "forstner",
+                "saddle_point",
+                "radon_peak",
+            ],
+            "refiner",
+        )?;
+        let mut cfg = Self::build(py)?;
+        if let Some(s) = extract_string(&dict, "kind", "refiner")? {
+            cfg.kind = parse_refinement_method(&s, "refiner.kind")?;
+        }
+        let com_type = py.get_type::<CenterOfMassConfig>();
+        let forstner_type = py.get_type::<ForstnerConfig>();
+        let saddle_type = py.get_type::<SaddlePointConfig>();
+        let radon_type = py.get_type::<RadonPeakConfig>();
+        if let Some(value) = dict.get_item("center_of_mass")? {
+            cfg.center_of_mass = Py::new(py, CenterOfMassConfig::from_dict(&com_type, &value)?)?;
+        }
+        if let Some(value) = dict.get_item("forstner")? {
+            cfg.forstner = Py::new(py, ForstnerConfig::from_dict(&forstner_type, &value)?)?;
+        }
+        if let Some(value) = dict.get_item("saddle_point")? {
+            cfg.saddle_point = Py::new(py, SaddlePointConfig::from_dict(&saddle_type, &value)?)?;
+        }
+        if let Some(value) = dict.get_item("radon_peak")? {
+            cfg.radon_peak = Py::new(py, RadonPeakConfig::from_dict(&radon_type, &value)?)?;
+        }
+        Ok(cfg)
+    }
+
+    #[pyo3(signature = (*, indent=None, sort_keys=true))]
+    fn to_json(&self, py: Python<'_>, indent: Option<i64>, sort_keys: bool) -> PyResult<String> {
+        let dict = self.to_dict(py)?;
+        json_dumps(py, dict.bind(py), indent, sort_keys)
+    }
+
+    #[classmethod]
+    fn from_json(cls: &Bound<'_, PyType>, py: Python<'_>, text: &str) -> PyResult<Self> {
+        let value = json_loads(py, text)
+            .map_err(|e| config_error(format!("failed to parse config JSON: {e}")))?;
+        Self::from_dict(cls, py, &value)
+    }
+
+    #[pyo3(signature = (*, indent=2, sort_keys=true))]
+    fn pretty(&self, py: Python<'_>, indent: i64, sort_keys: bool) -> PyResult<String> {
+        self.to_json(py, Some(indent), sort_keys)
+    }
+
+    fn __repr__(&self, py: Python<'_>) -> PyResult<String> {
+        self.pretty(py, 2, true)
+    }
+    fn __str__(&self, py: Python<'_>) -> PyResult<String> {
+        self.pretty(py, 2, true)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ChessConfig
+// ---------------------------------------------------------------------------
+
+#[pyclass(module = "chess_corners")]
+pub struct ChessConfig {
+    pub(crate) detector_mode: RsDetectorMode,
+    pub(crate) descriptor_mode: RsDescriptorMode,
+    pub(crate) threshold_mode: RsThresholdMode,
+    pub(crate) threshold_value: f32,
+    pub(crate) nms_radius: u32,
+    pub(crate) min_cluster_size: u32,
+    pub(crate) refiner: Py<RefinerConfig>,
+    pub(crate) pyramid_levels: u8,
+    pub(crate) pyramid_min_size: usize,
+    pub(crate) refinement_radius: u32,
+    pub(crate) merge_radius: f32,
+    pub(crate) radon_detector: Py<RadonDetectorParams>,
+}
+
+impl ChessConfig {
+    fn build(py: Python<'_>) -> PyResult<Self> {
+        let defaults = RsChessConfig::default();
+        Ok(Self {
+            detector_mode: defaults.detector_mode,
+            descriptor_mode: defaults.descriptor_mode,
+            // Match the prior Python dataclass defaults (Relative/0.2)
+            // rather than the Rust default (Absolute/0.0). Existing
+            // Python tests assume the relative-fraction default.
+            threshold_mode: RsThresholdMode::Relative,
+            threshold_value: 0.2,
+            nms_radius: defaults.nms_radius,
+            min_cluster_size: defaults.min_cluster_size,
+            refiner: Py::new(py, RefinerConfig::build(py)?)?,
+            pyramid_levels: defaults.pyramid_levels,
+            pyramid_min_size: defaults.pyramid_min_size,
+            refinement_radius: defaults.refinement_radius,
+            merge_radius: defaults.merge_radius,
+            radon_detector: Py::new(py, RadonDetectorParams::new())?,
+        })
+    }
+
+    /// Convert into the Rust facade's `ChessConfig` (consuming reads
+    /// of the nested Python wrappers).
+    pub(crate) fn to_inner(&self, py: Python<'_>) -> RsChessConfig {
+        let mut cfg = RsChessConfig::default();
+        cfg.detector_mode = self.detector_mode;
+        cfg.descriptor_mode = self.descriptor_mode;
+        cfg.threshold_mode = self.threshold_mode;
+        cfg.threshold_value = self.threshold_value;
+        cfg.nms_radius = self.nms_radius;
+        cfg.min_cluster_size = self.min_cluster_size;
+        cfg.refiner = self.refiner.borrow(py).to_inner(py);
+        cfg.pyramid_levels = self.pyramid_levels;
+        cfg.pyramid_min_size = self.pyramid_min_size;
+        cfg.refinement_radius = self.refinement_radius;
+        cfg.merge_radius = self.merge_radius;
+        cfg.radon_detector = self.radon_detector.borrow(py).inner;
+        cfg
+    }
+}
+
+#[pymethods]
+impl ChessConfig {
+    #[new]
+    fn py_new(py: Python<'_>) -> PyResult<Self> {
+        Self::build(py)
+    }
+
+    #[classmethod]
+    fn single_scale(_cls: &Bound<'_, PyType>, py: Python<'_>) -> PyResult<Self> {
+        Self::build(py)
+    }
+
+    #[classmethod]
+    fn multiscale(_cls: &Bound<'_, PyType>, py: Python<'_>) -> PyResult<Self> {
+        let mut cfg = Self::build(py)?;
+        cfg.pyramid_levels = 3;
+        cfg.pyramid_min_size = 128;
+        Ok(cfg)
+    }
+
+    #[classmethod]
+    fn radon(_cls: &Bound<'_, PyType>, py: Python<'_>) -> PyResult<Self> {
+        let mut cfg = Self::build(py)?;
+        cfg.detector_mode = RsDetectorMode::Radon;
+        cfg.pyramid_levels = 1;
+        Ok(cfg)
+    }
+
+    // ---- scalar fields ----
+
+    #[getter]
+    fn detector_mode(&self) -> DetectorMode {
+        self.detector_mode.into()
+    }
+    #[setter]
+    fn set_detector_mode(&mut self, v: DetectorMode) {
+        self.detector_mode = v.into();
+    }
+
+    #[getter]
+    fn descriptor_mode(&self) -> DescriptorMode {
+        self.descriptor_mode.into()
+    }
+    #[setter]
+    fn set_descriptor_mode(&mut self, v: DescriptorMode) {
+        self.descriptor_mode = v.into();
+    }
+
+    #[getter]
+    fn threshold_mode(&self) -> ThresholdMode {
+        self.threshold_mode.into()
+    }
+    #[setter]
+    fn set_threshold_mode(&mut self, v: ThresholdMode) {
+        self.threshold_mode = v.into();
+    }
+
+    #[getter]
+    fn threshold_value(&self) -> f32 {
+        self.threshold_value
+    }
+    #[setter]
+    fn set_threshold_value(&mut self, v: f32) {
+        self.threshold_value = v;
+    }
+
+    #[getter]
+    fn nms_radius(&self) -> u32 {
+        self.nms_radius
+    }
+    #[setter]
+    fn set_nms_radius(&mut self, v: u32) {
+        self.nms_radius = v;
+    }
+
+    #[getter]
+    fn min_cluster_size(&self) -> u32 {
+        self.min_cluster_size
+    }
+    #[setter]
+    fn set_min_cluster_size(&mut self, v: u32) {
+        self.min_cluster_size = v;
+    }
+
+    #[getter]
+    fn pyramid_levels(&self) -> u8 {
+        self.pyramid_levels
+    }
+    #[setter]
+    fn set_pyramid_levels(&mut self, v: u8) {
+        self.pyramid_levels = v;
+    }
+
+    #[getter]
+    fn pyramid_min_size(&self) -> usize {
+        self.pyramid_min_size
+    }
+    #[setter]
+    fn set_pyramid_min_size(&mut self, v: usize) {
+        self.pyramid_min_size = v;
+    }
+
+    #[getter]
+    fn refinement_radius(&self) -> u32 {
+        self.refinement_radius
+    }
+    #[setter]
+    fn set_refinement_radius(&mut self, v: u32) {
+        self.refinement_radius = v;
+    }
+
+    #[getter]
+    fn merge_radius(&self) -> f32 {
+        self.merge_radius
+    }
+    #[setter]
+    fn set_merge_radius(&mut self, v: f32) {
+        self.merge_radius = v;
+    }
+
+    // ---- nested wrappers (returned by reference) ----
+
+    #[getter]
+    fn refiner(&self, py: Python<'_>) -> Py<RefinerConfig> {
+        self.refiner.clone_ref(py)
+    }
+    #[setter]
+    fn set_refiner(&mut self, v: Py<RefinerConfig>) {
+        self.refiner = v;
+    }
+
+    #[getter]
+    fn radon_detector(&self, py: Python<'_>) -> Py<RadonDetectorParams> {
+        self.radon_detector.clone_ref(py)
+    }
+    #[setter]
+    fn set_radon_detector(&mut self, v: Py<RadonDetectorParams>) {
+        self.radon_detector = v;
+    }
+
+    // ---- serialization ----
+
+    fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyDict>> {
+        let d = PyDict::new(py);
+        d.set_item("detector_mode", detector_mode_str(self.detector_mode))?;
+        d.set_item("descriptor_mode", descriptor_mode_str(self.descriptor_mode))?;
+        d.set_item("threshold_mode", threshold_mode_str(self.threshold_mode))?;
+        d.set_item("threshold_value", self.threshold_value as f64)?;
+        d.set_item("nms_radius", self.nms_radius)?;
+        d.set_item("min_cluster_size", self.min_cluster_size)?;
+        d.set_item("refiner", self.refiner.borrow(py).to_dict(py)?)?;
+        d.set_item("pyramid_levels", self.pyramid_levels)?;
+        d.set_item("pyramid_min_size", self.pyramid_min_size)?;
+        d.set_item("refinement_radius", self.refinement_radius)?;
+        d.set_item("merge_radius", self.merge_radius as f64)?;
+        d.set_item(
+            "radon_detector",
+            self.radon_detector.borrow(py).to_dict(py)?,
+        )?;
+        Ok(d.unbind())
+    }
+
+    #[classmethod]
+    fn from_dict(
+        _cls: &Bound<'_, PyType>,
+        py: Python<'_>,
+        data: &Bound<'_, PyAny>,
+    ) -> PyResult<Self> {
+        let dict = require_dict(data, "config")?;
+        reject_unknown_keys(
+            &dict,
+            &[
+                "detector_mode",
+                "descriptor_mode",
+                "threshold_mode",
+                "threshold_value",
+                "nms_radius",
+                "min_cluster_size",
+                "refiner",
+                "pyramid_levels",
+                "pyramid_min_size",
+                "refinement_radius",
+                "merge_radius",
+                "radon_detector",
+            ],
+            "config",
+        )?;
+        let mut cfg = Self::build(py)?;
+        if let Some(s) = extract_string(&dict, "detector_mode", "config")? {
+            cfg.detector_mode = parse_detector_mode(&s, "config.detector_mode")?;
+        }
+        if let Some(s) = extract_string(&dict, "descriptor_mode", "config")? {
+            cfg.descriptor_mode = parse_descriptor_mode(&s, "config.descriptor_mode")?;
+        }
+        if let Some(s) = extract_string(&dict, "threshold_mode", "config")? {
+            cfg.threshold_mode = parse_threshold_mode(&s, "config.threshold_mode")?;
+        }
+        if let Some(v) = extract_float(&dict, "threshold_value", "config")? {
+            cfg.threshold_value = v as f32;
+        }
+        if let Some(v) = extract_int(&dict, "nms_radius", "config")? {
+            cfg.nms_radius = v as u32;
+        }
+        if let Some(v) = extract_int(&dict, "min_cluster_size", "config")? {
+            cfg.min_cluster_size = v as u32;
+        }
+        if let Some(value) = dict.get_item("refiner")? {
+            let refiner_type = py.get_type::<RefinerConfig>();
+            cfg.refiner = Py::new(py, RefinerConfig::from_dict(&refiner_type, py, &value)?)?;
+        }
+        if let Some(v) = extract_int(&dict, "pyramid_levels", "config")? {
+            cfg.pyramid_levels = v as u8;
+        }
+        if let Some(v) = extract_int(&dict, "pyramid_min_size", "config")? {
+            cfg.pyramid_min_size = v as usize;
+        }
+        if let Some(v) = extract_int(&dict, "refinement_radius", "config")? {
+            cfg.refinement_radius = v as u32;
+        }
+        if let Some(v) = extract_float(&dict, "merge_radius", "config")? {
+            cfg.merge_radius = v as f32;
+        }
+        if let Some(value) = dict.get_item("radon_detector")? {
+            let radon_type = py.get_type::<RadonDetectorParams>();
+            cfg.radon_detector = Py::new(py, RadonDetectorParams::from_dict(&radon_type, &value)?)?;
+        }
+        Ok(cfg)
+    }
+
+    #[pyo3(signature = (*, indent=None, sort_keys=true))]
+    fn to_json(&self, py: Python<'_>, indent: Option<i64>, sort_keys: bool) -> PyResult<String> {
+        let dict = self.to_dict(py)?;
+        json_dumps(py, dict.bind(py), indent, sort_keys)
+    }
+
+    #[classmethod]
+    fn from_json(cls: &Bound<'_, PyType>, py: Python<'_>, text: &str) -> PyResult<Self> {
+        let value = json_loads(py, text)
+            .map_err(|e| config_error(format!("failed to parse config JSON: {e}")))?;
+        Self::from_dict(cls, py, &value)
+    }
+
+    #[classmethod]
+    fn from_json_file(
+        cls: &Bound<'_, PyType>,
+        py: Python<'_>,
+        path: &Bound<'_, PyAny>,
+    ) -> PyResult<Self> {
+        let path_str: String = py
+            .import("os")?
+            .call_method1("fspath", (path,))?
+            .extract()?;
+        let text = std::fs::read_to_string(&path_str)
+            .map_err(|e| config_error(format!("failed to read config {path_str}: {e}")))?;
+        Self::from_json(cls, py, &text)
+    }
+
+    #[pyo3(signature = (*, indent=2, sort_keys=true))]
+    fn pretty(&self, py: Python<'_>, indent: i64, sort_keys: bool) -> PyResult<String> {
+        self.to_json(py, Some(indent), sort_keys)
+    }
+
+    fn __repr__(&self, py: Python<'_>) -> PyResult<String> {
+        self.pretty(py, 2, true)
+    }
+    fn __str__(&self, py: Python<'_>) -> PyResult<String> {
+        self.pretty(py, 2, true)
+    }
+}

--- a/crates/chess-corners-py/src/lib.rs
+++ b/crates/chess-corners-py/src/lib.rs
@@ -1,8 +1,26 @@
+//! Native Python bindings for the chess-corners detector.
+//!
+//! Exposes a typed [`config::ChessConfig`] (with nested
+//! [`config::RefinerConfig`], [`config::RadonDetectorParams`], and
+//! per-variant refiner configs) plus thin wrappers over the facade's
+//! detection entry points. The FFI accepts the typed config directly
+//! — no JSON serialization across the boundary — while preserving a
+//! string-only fallback so callers built against the older Python
+//! `to_json()`-then-pass-string path keep working for one release.
+
+mod config;
+
 use ::chess_corners as chess_corners_rs;
 use numpy::{ndarray::Array2, IntoPyArray, PyReadonlyArray2};
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyModule};
+
+use crate::config::{
+    CenterOfMassConfig, ChessConfig, ConfigError, DescriptorMode, DetectorMode, ForstnerConfig,
+    PeakFitMode, RadonDetectorParams, RadonPeakConfig, RefinementMethod, RefinerConfig,
+    SaddlePointConfig, ThresholdMode,
+};
 
 fn extract_image<'py>(
     image: &Bound<'py, PyAny>,
@@ -56,19 +74,37 @@ fn corners_to_array(
     Ok(out.into_pyarray(py).into_any().unbind())
 }
 
-fn resolve_cfg_json(cfg_json: Option<&str>) -> PyResult<chess_corners_rs::ChessConfig> {
-    match cfg_json {
-        Some(raw) => serde_json::from_str(raw)
-            .map_err(|err| PyValueError::new_err(format!("invalid config JSON: {err}"))),
-        None => Ok(chess_corners_rs::ChessConfig::default()),
+/// Resolve the optional `cfg` argument into a Rust facade
+/// `ChessConfig`. Accepts either a typed [`ChessConfig`] (preferred,
+/// no JSON across the boundary), or a JSON string (legacy path
+/// retained for one release). Anything else raises `TypeError`.
+fn resolve_config(
+    py: Python<'_>,
+    cfg: Option<&Bound<'_, PyAny>>,
+) -> PyResult<chess_corners_rs::ChessConfig> {
+    let Some(cfg) = cfg else {
+        return Ok(chess_corners_rs::ChessConfig::default());
+    };
+    if cfg.is_none() {
+        return Ok(chess_corners_rs::ChessConfig::default());
     }
+    if let Ok(typed) = cfg.cast::<ChessConfig>() {
+        return Ok(typed.borrow().to_inner(py));
+    }
+    if let Ok(json) = cfg.extract::<&str>() {
+        return serde_json::from_str(json)
+            .map_err(|err| PyValueError::new_err(format!("invalid config JSON: {err}")));
+    }
+    Err(PyTypeError::new_err(
+        "cfg must be a ChessConfig or a JSON string",
+    ))
 }
 
-#[pyfunction(signature = (image, cfg_json=None))]
+#[pyfunction(signature = (image, cfg=None))]
 fn find_chess_corners<'py>(
     py: Python<'py>,
     image: &Bound<'py, PyAny>,
-    cfg_json: Option<&str>,
+    cfg: Option<&Bound<'py, PyAny>>,
 ) -> PyResult<Py<PyAny>> {
     let (array, height, width) = extract_image(image)?;
     let view = array.as_array();
@@ -81,17 +117,17 @@ fn find_chess_corners<'py>(
     let height_u32 = u32::try_from(height)
         .map_err(|_| PyValueError::new_err("image height exceeds u32::MAX"))?;
 
-    let cfg = resolve_cfg_json(cfg_json)?;
+    let cfg = resolve_config(py, cfg)?;
     let corners = chess_corners_rs::find_chess_corners_u8(slice, width_u32, height_u32, &cfg);
     corners_to_array(py, corners)
 }
 
 #[cfg(feature = "ml-refiner")]
-#[pyfunction(signature = (image, cfg_json=None))]
+#[pyfunction(signature = (image, cfg=None))]
 fn find_chess_corners_with_ml<'py>(
     py: Python<'py>,
     image: &Bound<'py, PyAny>,
-    cfg_json: Option<&str>,
+    cfg: Option<&Bound<'py, PyAny>>,
 ) -> PyResult<Py<PyAny>> {
     let (array, height, width) = extract_image(image)?;
     let view = array.as_array();
@@ -104,17 +140,17 @@ fn find_chess_corners_with_ml<'py>(
     let height_u32 = u32::try_from(height)
         .map_err(|_| PyValueError::new_err("image height exceeds u32::MAX"))?;
 
-    let cfg = resolve_cfg_json(cfg_json)?;
+    let cfg = resolve_config(py, cfg)?;
     let corners =
         chess_corners_rs::find_chess_corners_u8_with_ml(slice, width_u32, height_u32, &cfg);
     corners_to_array(py, corners)
 }
 
-#[pyfunction(signature = (image, cfg_json=None))]
+#[pyfunction(signature = (image, cfg=None))]
 fn radon_heatmap<'py>(
     py: Python<'py>,
     image: &Bound<'py, PyAny>,
-    cfg_json: Option<&str>,
+    cfg: Option<&Bound<'py, PyAny>>,
 ) -> PyResult<Py<PyAny>> {
     let (array, height, width) = extract_image(image)?;
     let view = array.as_array();
@@ -127,7 +163,7 @@ fn radon_heatmap<'py>(
     let height_u32 = u32::try_from(height)
         .map_err(|_| PyValueError::new_err("image height exceeds u32::MAX"))?;
 
-    let cfg = resolve_cfg_json(cfg_json)?;
+    let cfg = resolve_config(py, cfg)?;
     let map = chess_corners_rs::radon_heatmap_u8(slice, width_u32, height_u32, &cfg);
 
     let arr = Array2::from_shape_vec((map.height(), map.width()), map.data().to_vec())
@@ -136,7 +172,23 @@ fn radon_heatmap<'py>(
 }
 
 #[pymodule(name = "_native")]
-fn native_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
+fn native_module(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add("ConfigError", py.get_type::<ConfigError>())?;
+
+    m.add_class::<DetectorMode>()?;
+    m.add_class::<DescriptorMode>()?;
+    m.add_class::<ThresholdMode>()?;
+    m.add_class::<RefinementMethod>()?;
+    m.add_class::<PeakFitMode>()?;
+
+    m.add_class::<CenterOfMassConfig>()?;
+    m.add_class::<ForstnerConfig>()?;
+    m.add_class::<SaddlePointConfig>()?;
+    m.add_class::<RadonPeakConfig>()?;
+    m.add_class::<RadonDetectorParams>()?;
+    m.add_class::<RefinerConfig>()?;
+    m.add_class::<ChessConfig>()?;
+
     m.add_function(wrap_pyfunction!(find_chess_corners, m)?)?;
     m.add_function(wrap_pyfunction!(radon_heatmap, m)?)?;
     #[cfg(feature = "ml-refiner")]

--- a/crates/chess-corners-wasm/Cargo.toml
+++ b/crates/chess-corners-wasm/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 chess-corners.workspace = true
-chess-corners-core = { path = "../chess-corners-core", version = "0.6.0", default-features = false, features = ["std"] }
+chess-corners-core = { path = "../chess-corners-core", version = "0.7.0", default-features = false, features = ["std"] }
 wasm-bindgen.workspace = true
 js-sys.workspace = true
 

--- a/crates/chess-corners-wasm/README.md
+++ b/crates/chess-corners-wasm/README.md
@@ -165,6 +165,14 @@ Every public Rust facade field is reachable through the typed
 classes and exposed with TypeScript types in the generated
 `.d.ts`.
 
+**Round-trip idiom for nested edits.** `wasm-bindgen` getters that
+return a struct (e.g. `cfg.refiner`, `cfg.radonDetector`,
+`cfg.upscale`, and the per-variant `cfg.refiner.forstner` etc.) hand
+back a *clone*, not a live view. To persist a nested edit, capture
+the getter result, mutate it, and assign it back through the parent
+setter. Top-level scalar setters (`cfg.thresholdValue = ...`) work
+in place because they mutate the parent directly.
+
 ```ts
 import init, {
   ChessConfig,
@@ -177,18 +185,27 @@ import init, {
 await init();
 
 const cfg = ChessConfig.multiscale();
+
+// Top-level scalar fields mutate `cfg` directly.
 cfg.detectorMode = DetectorMode.Radon;
 cfg.thresholdValue = 0.15;
-cfg.refiner.kind = RefinementMethod.RadonPeak;
-cfg.radonDetector.rayRadius = 5;
-cfg.radonDetector.imageUpsample = 2;
-cfg.radonDetector.peakFit = PeakFitMode.Gaussian;
+
+// Nested edits use the round-trip pattern: read, mutate, write back.
+const refiner = cfg.refiner;
+refiner.kind = RefinementMethod.RadonPeak;
+cfg.refiner = refiner;
+
+const radon = cfg.radonDetector;
+radon.rayRadius = 5;
+radon.imageUpsample = 2;
+radon.peakFit = PeakFitMode.Gaussian;
+cfg.radonDetector = radon;
 
 const detector = ChessDetector.withConfig(cfg);
 
 // Snapshot / commit changes via the typed config later if needed:
 const snapshot = detector.getConfig();
-snapshot.nmsRadius = 4;
+snapshot.nmsRadius = 4;             // top-level: in-place
 detector.applyConfig(snapshot);
 ```
 

--- a/crates/chess-corners-wasm/README.md
+++ b/crates/chess-corners-wasm/README.md
@@ -156,6 +156,46 @@ detector.set_pyramid_min_size(128);
 detector.set_refiner("forstner");
 ```
 
+### Typed configuration (full surface)
+
+For deeper tuning — refiner subconfig, Radon detector parameters,
+descriptor mode, coarse-to-fine radii — construct a typed
+`ChessConfig` and seed the detector with `ChessDetector.withConfig`.
+Every public Rust facade field is reachable through the typed
+classes and exposed with TypeScript types in the generated
+`.d.ts`.
+
+```ts
+import init, {
+  ChessConfig,
+  ChessDetector,
+  DetectorMode,
+  PeakFitMode,
+  RefinementMethod,
+} from '@vitavision/chess-corners';
+
+await init();
+
+const cfg = ChessConfig.multiscale();
+cfg.detectorMode = DetectorMode.Radon;
+cfg.thresholdValue = 0.15;
+cfg.refiner.kind = RefinementMethod.RadonPeak;
+cfg.radonDetector.rayRadius = 5;
+cfg.radonDetector.imageUpsample = 2;
+cfg.radonDetector.peakFit = PeakFitMode.Gaussian;
+
+const detector = ChessDetector.withConfig(cfg);
+
+// Snapshot / commit changes via the typed config later if needed:
+const snapshot = detector.getConfig();
+snapshot.nmsRadius = 4;
+detector.applyConfig(snapshot);
+```
+
+The legacy `set_*` shortcut methods continue to work and edit the
+same underlying configuration, so the two styles can be mixed at
+will.
+
 ## API Reference
 
 ### `ChessDetector`

--- a/crates/chess-corners-wasm/README.md
+++ b/crates/chess-corners-wasm/README.md
@@ -165,13 +165,9 @@ Every public Rust facade field is reachable through the typed
 classes and exposed with TypeScript types in the generated
 `.d.ts`.
 
-**Round-trip idiom for nested edits.** `wasm-bindgen` getters that
-return a struct (e.g. `cfg.refiner`, `cfg.radonDetector`,
-`cfg.upscale`, and the per-variant `cfg.refiner.forstner` etc.) hand
-back a *clone*, not a live view. To persist a nested edit, capture
-the getter result, mutate it, and assign it back through the parent
-setter. Top-level scalar setters (`cfg.thresholdValue = ...`) work
-in place because they mutate the parent directly.
+Nested config edits propagate naturally — getters hand back a
+wrapper backed by the same shared cell as the parent, so chained
+mutation works without a round-trip:
 
 ```ts
 import init, {
@@ -185,29 +181,29 @@ import init, {
 await init();
 
 const cfg = ChessConfig.multiscale();
-
-// Top-level scalar fields mutate `cfg` directly.
 cfg.detectorMode = DetectorMode.Radon;
 cfg.thresholdValue = 0.15;
-
-// Nested edits use the round-trip pattern: read, mutate, write back.
-const refiner = cfg.refiner;
-refiner.kind = RefinementMethod.RadonPeak;
-cfg.refiner = refiner;
-
-const radon = cfg.radonDetector;
-radon.rayRadius = 5;
-radon.imageUpsample = 2;
-radon.peakFit = PeakFitMode.Gaussian;
-cfg.radonDetector = radon;
+cfg.refiner.kind = RefinementMethod.RadonPeak;
+cfg.refiner.forstner.maxOffset = 2.0;
+cfg.radonDetector.rayRadius = 5;
+cfg.radonDetector.imageUpsample = 2;
+cfg.radonDetector.peakFit = PeakFitMode.Gaussian;
 
 const detector = ChessDetector.withConfig(cfg);
 
-// Snapshot / commit changes via the typed config later if needed:
+// `getConfig()` returns a *snapshot* — its cells are independent of
+// the detector's live state. Use `applyConfig()` to commit changes
+// made on the snapshot.
 const snapshot = detector.getConfig();
-snapshot.nmsRadius = 4;             // top-level: in-place
+snapshot.nmsRadius = 4;
 detector.applyConfig(snapshot);
 ```
+
+Setters that take a nested wrapper (e.g. `cfg.refiner = newRefiner`)
+reseat `cfg`'s shared cells to point at `newRefiner`'s cells, so
+future `cfg.refiner.*` calls observe `newRefiner`'s state. JS code
+that already held the previous `cfg.refiner` keeps observing the
+previous cells — matching natural JS attribute-replacement semantics.
 
 The legacy `set_*` shortcut methods continue to work and edit the
 same underlying configuration, so the two styles can be mixed at

--- a/crates/chess-corners-wasm/src/config.rs
+++ b/crates/chess-corners-wasm/src/config.rs
@@ -1052,9 +1052,7 @@ mod tests {
     //! identical on host and on wasm32.
 
     use super::*;
-    use chess_corners::{
-        DetectorMode as RsDetectorMode, RefinementMethod as RsRefinementMethod,
-    };
+    use chess_corners::{DetectorMode as RsDetectorMode, RefinementMethod as RsRefinementMethod};
 
     #[test]
     fn nested_edits_propagate_through_chess_config() {

--- a/crates/chess-corners-wasm/src/config.rs
+++ b/crates/chess-corners-wasm/src/config.rs
@@ -1,17 +1,40 @@
 //! Typed `#[wasm_bindgen]` wrappers around `chess-corners` config
 //! structs.
 //!
-//! Each wrapper stores its inner Rust value by value and exposes
-//! per-field getters/setters with TypeScript-friendly types. The
-//! wrappers do not own any state beyond the inner value — passing a
-//! wrapper into `ChessDetector::with_config` clones the inner Rust
-//! struct.
+//! ## Live nested edits
+//!
+//! Each wrapper stores its inner Rust value in a shared
+//! `Rc<RefCell<T>>` cell, and compound wrappers (`RefinerConfig`,
+//! `ChessConfig`) hold `Rc` handles to their children's cells. A
+//! getter returns a wrapper backed by the same cell as the parent,
+//! so chained mutation propagates without a round-trip:
+//!
+//! ```js
+//! const cfg = ChessConfig.multiscale();
+//! cfg.refiner.kind = RefinementMethod.RadonPeak;        // works
+//! cfg.refiner.forstner.maxOffset = 2.0;                  // works
+//! cfg.radonDetector.rayRadius = 5;                       // works
+//! ```
+//!
+//! Setters that take a nested wrapper (e.g. `cfg.refiner = newCfg`)
+//! reseat the parent's `Rc` to point at the new value's cell, so
+//! future getter calls return wrappers backed by the new cell. Any
+//! JS reference held to the *previous* nested wrapper still
+//! observes the previous cell — matching natural attribute-
+//! reassignment semantics in JS.
+//!
+//! Single-threaded `Rc<RefCell<T>>` is sound on
+//! `wasm32-unknown-unknown`; wasm-bindgen modules are not shared
+//! across worker threads.
 //!
 //! Why a wrapper layer at all? The Rust source-of-truth structs live
 //! in `chess-corners` / `chess-corners-core` and must not depend on
 //! `wasm-bindgen` (per the workspace dependency rule in `AGENTS.md`).
 //! These wrappers add the JS-facing attribute layer in the WASM
 //! crate only.
+
+use std::cell::RefCell;
+use std::rc::Rc;
 
 use chess_corners::{
     CenterOfMassConfig as RsCenterOfMassConfig, ChessConfig as RsChessConfig,
@@ -23,6 +46,14 @@ use chess_corners::{
     UpscaleConfig as RsUpscaleConfig, UpscaleMode as RsUpscaleMode,
 };
 use wasm_bindgen::prelude::*;
+
+/// Shared mutable cell used by every wrapper. Single-threaded;
+/// `wasm-bindgen` instances live entirely on one JS thread.
+type Cell<T> = Rc<RefCell<T>>;
+
+fn cell<T>(value: T) -> Cell<T> {
+    Rc::new(RefCell::new(value))
+}
 
 // ---------------------------------------------------------------------------
 // Enums
@@ -206,11 +237,10 @@ impl From<RsUpscaleMode> for UpscaleMode {
 // CenterOfMassConfig
 // ---------------------------------------------------------------------------
 
-/// Center-of-mass refiner configuration.
 #[wasm_bindgen]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct CenterOfMassConfig {
-    inner: RsCenterOfMassConfig,
+    cell: Cell<RsCenterOfMassConfig>,
 }
 
 #[wasm_bindgen]
@@ -218,17 +248,17 @@ impl CenterOfMassConfig {
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
         Self {
-            inner: RsCenterOfMassConfig::default(),
+            cell: cell(RsCenterOfMassConfig::default()),
         }
     }
 
     #[wasm_bindgen(getter)]
     pub fn radius(&self) -> i32 {
-        self.inner.radius
+        self.cell.borrow().radius
     }
     #[wasm_bindgen(setter)]
     pub fn set_radius(&mut self, v: i32) {
-        self.inner.radius = v;
+        self.cell.borrow_mut().radius = v;
     }
 }
 
@@ -239,11 +269,11 @@ impl Default for CenterOfMassConfig {
 }
 
 impl CenterOfMassConfig {
-    pub(crate) fn inner(&self) -> RsCenterOfMassConfig {
-        self.inner
+    pub(crate) fn share_cell(&self) -> Cell<RsCenterOfMassConfig> {
+        Rc::clone(&self.cell)
     }
-    pub(crate) fn from_inner(inner: RsCenterOfMassConfig) -> Self {
-        Self { inner }
+    pub(crate) fn from_cell(cell: Cell<RsCenterOfMassConfig>) -> Self {
+        Self { cell }
     }
 }
 
@@ -251,11 +281,10 @@ impl CenterOfMassConfig {
 // ForstnerConfig
 // ---------------------------------------------------------------------------
 
-/// Förstner gradient-based refiner configuration.
 #[wasm_bindgen]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct ForstnerConfig {
-    inner: RsForstnerConfig,
+    cell: Cell<RsForstnerConfig>,
 }
 
 #[wasm_bindgen]
@@ -263,53 +292,53 @@ impl ForstnerConfig {
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
         Self {
-            inner: RsForstnerConfig::default(),
+            cell: cell(RsForstnerConfig::default()),
         }
     }
 
     #[wasm_bindgen(getter)]
     pub fn radius(&self) -> i32 {
-        self.inner.radius
+        self.cell.borrow().radius
     }
     #[wasm_bindgen(setter)]
     pub fn set_radius(&mut self, v: i32) {
-        self.inner.radius = v;
+        self.cell.borrow_mut().radius = v;
     }
 
     #[wasm_bindgen(getter, js_name = minTrace)]
     pub fn min_trace(&self) -> f32 {
-        self.inner.min_trace
+        self.cell.borrow().min_trace
     }
     #[wasm_bindgen(setter, js_name = minTrace)]
     pub fn set_min_trace(&mut self, v: f32) {
-        self.inner.min_trace = v;
+        self.cell.borrow_mut().min_trace = v;
     }
 
     #[wasm_bindgen(getter, js_name = minDet)]
     pub fn min_det(&self) -> f32 {
-        self.inner.min_det
+        self.cell.borrow().min_det
     }
     #[wasm_bindgen(setter, js_name = minDet)]
     pub fn set_min_det(&mut self, v: f32) {
-        self.inner.min_det = v;
+        self.cell.borrow_mut().min_det = v;
     }
 
     #[wasm_bindgen(getter, js_name = maxConditionNumber)]
     pub fn max_condition_number(&self) -> f32 {
-        self.inner.max_condition_number
+        self.cell.borrow().max_condition_number
     }
     #[wasm_bindgen(setter, js_name = maxConditionNumber)]
     pub fn set_max_condition_number(&mut self, v: f32) {
-        self.inner.max_condition_number = v;
+        self.cell.borrow_mut().max_condition_number = v;
     }
 
     #[wasm_bindgen(getter, js_name = maxOffset)]
     pub fn max_offset(&self) -> f32 {
-        self.inner.max_offset
+        self.cell.borrow().max_offset
     }
     #[wasm_bindgen(setter, js_name = maxOffset)]
     pub fn set_max_offset(&mut self, v: f32) {
-        self.inner.max_offset = v;
+        self.cell.borrow_mut().max_offset = v;
     }
 }
 
@@ -320,11 +349,11 @@ impl Default for ForstnerConfig {
 }
 
 impl ForstnerConfig {
-    pub(crate) fn inner(&self) -> RsForstnerConfig {
-        self.inner
+    pub(crate) fn share_cell(&self) -> Cell<RsForstnerConfig> {
+        Rc::clone(&self.cell)
     }
-    pub(crate) fn from_inner(inner: RsForstnerConfig) -> Self {
-        Self { inner }
+    pub(crate) fn from_cell(cell: Cell<RsForstnerConfig>) -> Self {
+        Self { cell }
     }
 }
 
@@ -332,11 +361,10 @@ impl ForstnerConfig {
 // SaddlePointConfig
 // ---------------------------------------------------------------------------
 
-/// Quadratic saddle-point refiner configuration.
 #[wasm_bindgen]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct SaddlePointConfig {
-    inner: RsSaddlePointConfig,
+    cell: Cell<RsSaddlePointConfig>,
 }
 
 #[wasm_bindgen]
@@ -344,44 +372,44 @@ impl SaddlePointConfig {
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
         Self {
-            inner: RsSaddlePointConfig::default(),
+            cell: cell(RsSaddlePointConfig::default()),
         }
     }
 
     #[wasm_bindgen(getter)]
     pub fn radius(&self) -> i32 {
-        self.inner.radius
+        self.cell.borrow().radius
     }
     #[wasm_bindgen(setter)]
     pub fn set_radius(&mut self, v: i32) {
-        self.inner.radius = v;
+        self.cell.borrow_mut().radius = v;
     }
 
     #[wasm_bindgen(getter, js_name = detMargin)]
     pub fn det_margin(&self) -> f32 {
-        self.inner.det_margin
+        self.cell.borrow().det_margin
     }
     #[wasm_bindgen(setter, js_name = detMargin)]
     pub fn set_det_margin(&mut self, v: f32) {
-        self.inner.det_margin = v;
+        self.cell.borrow_mut().det_margin = v;
     }
 
     #[wasm_bindgen(getter, js_name = maxOffset)]
     pub fn max_offset(&self) -> f32 {
-        self.inner.max_offset
+        self.cell.borrow().max_offset
     }
     #[wasm_bindgen(setter, js_name = maxOffset)]
     pub fn set_max_offset(&mut self, v: f32) {
-        self.inner.max_offset = v;
+        self.cell.borrow_mut().max_offset = v;
     }
 
     #[wasm_bindgen(getter, js_name = minAbsDet)]
     pub fn min_abs_det(&self) -> f32 {
-        self.inner.min_abs_det
+        self.cell.borrow().min_abs_det
     }
     #[wasm_bindgen(setter, js_name = minAbsDet)]
     pub fn set_min_abs_det(&mut self, v: f32) {
-        self.inner.min_abs_det = v;
+        self.cell.borrow_mut().min_abs_det = v;
     }
 }
 
@@ -392,11 +420,11 @@ impl Default for SaddlePointConfig {
 }
 
 impl SaddlePointConfig {
-    pub(crate) fn inner(&self) -> RsSaddlePointConfig {
-        self.inner
+    pub(crate) fn share_cell(&self) -> Cell<RsSaddlePointConfig> {
+        Rc::clone(&self.cell)
     }
-    pub(crate) fn from_inner(inner: RsSaddlePointConfig) -> Self {
-        Self { inner }
+    pub(crate) fn from_cell(cell: Cell<RsSaddlePointConfig>) -> Self {
+        Self { cell }
     }
 }
 
@@ -404,11 +432,10 @@ impl SaddlePointConfig {
 // RadonPeakConfig
 // ---------------------------------------------------------------------------
 
-/// Radon-peak refiner configuration.
 #[wasm_bindgen]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct RadonPeakConfig {
-    inner: RsRadonPeakConfig,
+    cell: Cell<RsRadonPeakConfig>,
 }
 
 #[wasm_bindgen]
@@ -416,71 +443,71 @@ impl RadonPeakConfig {
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
         Self {
-            inner: RsRadonPeakConfig::default(),
+            cell: cell(RsRadonPeakConfig::default()),
         }
     }
 
     #[wasm_bindgen(getter, js_name = rayRadius)]
     pub fn ray_radius(&self) -> u32 {
-        self.inner.ray_radius
+        self.cell.borrow().ray_radius
     }
     #[wasm_bindgen(setter, js_name = rayRadius)]
     pub fn set_ray_radius(&mut self, v: u32) {
-        self.inner.ray_radius = v;
+        self.cell.borrow_mut().ray_radius = v;
     }
 
     #[wasm_bindgen(getter, js_name = patchRadius)]
     pub fn patch_radius(&self) -> u32 {
-        self.inner.patch_radius
+        self.cell.borrow().patch_radius
     }
     #[wasm_bindgen(setter, js_name = patchRadius)]
     pub fn set_patch_radius(&mut self, v: u32) {
-        self.inner.patch_radius = v;
+        self.cell.borrow_mut().patch_radius = v;
     }
 
     #[wasm_bindgen(getter, js_name = imageUpsample)]
     pub fn image_upsample(&self) -> u32 {
-        self.inner.image_upsample
+        self.cell.borrow().image_upsample
     }
     #[wasm_bindgen(setter, js_name = imageUpsample)]
     pub fn set_image_upsample(&mut self, v: u32) {
-        self.inner.image_upsample = v;
+        self.cell.borrow_mut().image_upsample = v;
     }
 
     #[wasm_bindgen(getter, js_name = responseBlurRadius)]
     pub fn response_blur_radius(&self) -> u32 {
-        self.inner.response_blur_radius
+        self.cell.borrow().response_blur_radius
     }
     #[wasm_bindgen(setter, js_name = responseBlurRadius)]
     pub fn set_response_blur_radius(&mut self, v: u32) {
-        self.inner.response_blur_radius = v;
+        self.cell.borrow_mut().response_blur_radius = v;
     }
 
     #[wasm_bindgen(getter, js_name = peakFit)]
     pub fn peak_fit(&self) -> PeakFitMode {
-        self.inner.peak_fit.into()
+        self.cell.borrow().peak_fit.into()
     }
     #[wasm_bindgen(setter, js_name = peakFit)]
     pub fn set_peak_fit(&mut self, v: PeakFitMode) {
-        self.inner.peak_fit = v.into();
+        self.cell.borrow_mut().peak_fit = v.into();
     }
 
     #[wasm_bindgen(getter, js_name = minResponse)]
     pub fn min_response(&self) -> f32 {
-        self.inner.min_response
+        self.cell.borrow().min_response
     }
     #[wasm_bindgen(setter, js_name = minResponse)]
     pub fn set_min_response(&mut self, v: f32) {
-        self.inner.min_response = v;
+        self.cell.borrow_mut().min_response = v;
     }
 
     #[wasm_bindgen(getter, js_name = maxOffset)]
     pub fn max_offset(&self) -> f32 {
-        self.inner.max_offset
+        self.cell.borrow().max_offset
     }
     #[wasm_bindgen(setter, js_name = maxOffset)]
     pub fn set_max_offset(&mut self, v: f32) {
-        self.inner.max_offset = v;
+        self.cell.borrow_mut().max_offset = v;
     }
 }
 
@@ -491,11 +518,11 @@ impl Default for RadonPeakConfig {
 }
 
 impl RadonPeakConfig {
-    pub(crate) fn inner(&self) -> RsRadonPeakConfig {
-        self.inner
+    pub(crate) fn share_cell(&self) -> Cell<RsRadonPeakConfig> {
+        Rc::clone(&self.cell)
     }
-    pub(crate) fn from_inner(inner: RsRadonPeakConfig) -> Self {
-        Self { inner }
+    pub(crate) fn from_cell(cell: Cell<RsRadonPeakConfig>) -> Self {
+        Self { cell }
     }
 }
 
@@ -503,17 +530,20 @@ impl RadonPeakConfig {
 // RefinerConfig
 // ---------------------------------------------------------------------------
 
-/// Subpixel refiner selection plus per-variant parameters.
-///
-/// **Round-trip idiom for nested edits.** Per-variant getters
-/// (`centerOfMass`, `forstner`, `saddlePoint`, `radonPeak`) return a
-/// fresh clone of the inner config. Editing the returned object does
-/// not flow back; assign through the parent setter instead. See the
-/// crate-level docs for the full pattern.
 #[wasm_bindgen]
 #[derive(Clone, Debug)]
 pub struct RefinerConfig {
-    inner: RsRefinerConfig,
+    /// Scalar `kind` field. Stored in its own cell so reseating
+    /// `cfg.refiner = newOne` brings the new kind cell along with
+    /// the per-variant cells.
+    kind: Cell<RsRefinementMethod>,
+    /// Per-variant cells. Each cell is shared with the corresponding
+    /// per-variant wrapper returned from getters — mutating either
+    /// side updates both.
+    center_of_mass: Cell<RsCenterOfMassConfig>,
+    forstner: Cell<RsForstnerConfig>,
+    saddle_point: Cell<RsSaddlePointConfig>,
+    radon_peak: Cell<RsRadonPeakConfig>,
 }
 
 #[wasm_bindgen]
@@ -521,66 +551,57 @@ impl RefinerConfig {
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
         Self {
-            inner: RsRefinerConfig::default(),
+            kind: cell(RsRefinementMethod::default()),
+            center_of_mass: cell(RsCenterOfMassConfig::default()),
+            forstner: cell(RsForstnerConfig::default()),
+            saddle_point: cell(RsSaddlePointConfig::default()),
+            radon_peak: cell(RsRadonPeakConfig::default()),
         }
     }
 
     #[wasm_bindgen(getter)]
     pub fn kind(&self) -> RefinementMethod {
-        self.inner.kind.into()
+        (*self.kind.borrow()).into()
     }
     #[wasm_bindgen(setter)]
     pub fn set_kind(&mut self, v: RefinementMethod) {
-        self.inner.kind = v.into();
+        *self.kind.borrow_mut() = v.into();
     }
 
-    /// Returns a *clone* of the per-variant config. Mutate it and
-    /// assign it back via [`Self::set_center_of_mass`] to persist
-    /// the edit (see crate-level docs for the round-trip idiom).
     #[wasm_bindgen(getter, js_name = centerOfMass)]
     pub fn center_of_mass(&self) -> CenterOfMassConfig {
-        CenterOfMassConfig::from_inner(self.inner.center_of_mass)
+        CenterOfMassConfig::from_cell(Rc::clone(&self.center_of_mass))
     }
     #[wasm_bindgen(setter, js_name = centerOfMass)]
     pub fn set_center_of_mass(&mut self, v: &CenterOfMassConfig) {
-        self.inner.center_of_mass = v.inner();
+        self.center_of_mass = v.share_cell();
     }
 
-    /// Returns a *clone* of the Förstner refiner config. Mutate it
-    /// and assign it back via [`Self::set_forstner`] to persist the
-    /// edit (see crate-level docs for the round-trip idiom).
     #[wasm_bindgen(getter)]
     pub fn forstner(&self) -> ForstnerConfig {
-        ForstnerConfig::from_inner(self.inner.forstner)
+        ForstnerConfig::from_cell(Rc::clone(&self.forstner))
     }
     #[wasm_bindgen(setter)]
     pub fn set_forstner(&mut self, v: &ForstnerConfig) {
-        self.inner.forstner = v.inner();
+        self.forstner = v.share_cell();
     }
 
-    /// Returns a *clone* of the saddle-point refiner config. Mutate
-    /// it and assign it back via [`Self::set_saddle_point`] to
-    /// persist the edit (see crate-level docs for the round-trip
-    /// idiom).
     #[wasm_bindgen(getter, js_name = saddlePoint)]
     pub fn saddle_point(&self) -> SaddlePointConfig {
-        SaddlePointConfig::from_inner(self.inner.saddle_point)
+        SaddlePointConfig::from_cell(Rc::clone(&self.saddle_point))
     }
     #[wasm_bindgen(setter, js_name = saddlePoint)]
     pub fn set_saddle_point(&mut self, v: &SaddlePointConfig) {
-        self.inner.saddle_point = v.inner();
+        self.saddle_point = v.share_cell();
     }
 
-    /// Returns a *clone* of the Radon-peak refiner config. Mutate it
-    /// and assign it back via [`Self::set_radon_peak`] to persist
-    /// the edit (see crate-level docs for the round-trip idiom).
     #[wasm_bindgen(getter, js_name = radonPeak)]
     pub fn radon_peak(&self) -> RadonPeakConfig {
-        RadonPeakConfig::from_inner(self.inner.radon_peak)
+        RadonPeakConfig::from_cell(Rc::clone(&self.radon_peak))
     }
     #[wasm_bindgen(setter, js_name = radonPeak)]
     pub fn set_radon_peak(&mut self, v: &RadonPeakConfig) {
-        self.inner.radon_peak = v.inner();
+        self.radon_peak = v.share_cell();
     }
 }
 
@@ -591,11 +612,24 @@ impl Default for RefinerConfig {
 }
 
 impl RefinerConfig {
-    pub(crate) fn inner(&self) -> RsRefinerConfig {
-        self.inner.clone()
+    pub(crate) fn snapshot(&self) -> RsRefinerConfig {
+        RsRefinerConfig {
+            kind: *self.kind.borrow(),
+            center_of_mass: *self.center_of_mass.borrow(),
+            forstner: *self.forstner.borrow(),
+            saddle_point: *self.saddle_point.borrow(),
+            radon_peak: *self.radon_peak.borrow(),
+        }
     }
-    pub(crate) fn from_inner(inner: RsRefinerConfig) -> Self {
-        Self { inner }
+
+    pub(crate) fn from_value(value: RsRefinerConfig) -> Self {
+        Self {
+            kind: cell(value.kind),
+            center_of_mass: cell(value.center_of_mass),
+            forstner: cell(value.forstner),
+            saddle_point: cell(value.saddle_point),
+            radon_peak: cell(value.radon_peak),
+        }
     }
 }
 
@@ -603,11 +637,10 @@ impl RefinerConfig {
 // RadonDetectorParams
 // ---------------------------------------------------------------------------
 
-/// Whole-image Radon detector parameters.
 #[wasm_bindgen]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct RadonDetectorParams {
-    inner: RsRadonDetectorParams,
+    cell: Cell<RsRadonDetectorParams>,
 }
 
 #[wasm_bindgen]
@@ -615,82 +648,82 @@ impl RadonDetectorParams {
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
         Self {
-            inner: RsRadonDetectorParams::default(),
+            cell: cell(RsRadonDetectorParams::default()),
         }
     }
 
     #[wasm_bindgen(getter, js_name = rayRadius)]
     pub fn ray_radius(&self) -> u32 {
-        self.inner.ray_radius
+        self.cell.borrow().ray_radius
     }
     #[wasm_bindgen(setter, js_name = rayRadius)]
     pub fn set_ray_radius(&mut self, v: u32) {
-        self.inner.ray_radius = v;
+        self.cell.borrow_mut().ray_radius = v;
     }
 
     #[wasm_bindgen(getter, js_name = imageUpsample)]
     pub fn image_upsample(&self) -> u32 {
-        self.inner.image_upsample
+        self.cell.borrow().image_upsample
     }
     #[wasm_bindgen(setter, js_name = imageUpsample)]
     pub fn set_image_upsample(&mut self, v: u32) {
-        self.inner.image_upsample = v;
+        self.cell.borrow_mut().image_upsample = v;
     }
 
     #[wasm_bindgen(getter, js_name = responseBlurRadius)]
     pub fn response_blur_radius(&self) -> u32 {
-        self.inner.response_blur_radius
+        self.cell.borrow().response_blur_radius
     }
     #[wasm_bindgen(setter, js_name = responseBlurRadius)]
     pub fn set_response_blur_radius(&mut self, v: u32) {
-        self.inner.response_blur_radius = v;
+        self.cell.borrow_mut().response_blur_radius = v;
     }
 
     #[wasm_bindgen(getter, js_name = peakFit)]
     pub fn peak_fit(&self) -> PeakFitMode {
-        self.inner.peak_fit.into()
+        self.cell.borrow().peak_fit.into()
     }
     #[wasm_bindgen(setter, js_name = peakFit)]
     pub fn set_peak_fit(&mut self, v: PeakFitMode) {
-        self.inner.peak_fit = v.into();
+        self.cell.borrow_mut().peak_fit = v.into();
     }
 
     #[wasm_bindgen(getter, js_name = thresholdRel)]
     pub fn threshold_rel(&self) -> f32 {
-        self.inner.threshold_rel
+        self.cell.borrow().threshold_rel
     }
     #[wasm_bindgen(setter, js_name = thresholdRel)]
     pub fn set_threshold_rel(&mut self, v: f32) {
-        self.inner.threshold_rel = v;
+        self.cell.borrow_mut().threshold_rel = v;
     }
 
     /// Absolute response floor; `None` to clear and let the relative
     /// threshold decide. Pass a finite number to override.
     #[wasm_bindgen(getter, js_name = thresholdAbs)]
     pub fn threshold_abs(&self) -> Option<f32> {
-        self.inner.threshold_abs
+        self.cell.borrow().threshold_abs
     }
     #[wasm_bindgen(setter, js_name = thresholdAbs)]
     pub fn set_threshold_abs(&mut self, v: Option<f32>) {
-        self.inner.threshold_abs = v;
+        self.cell.borrow_mut().threshold_abs = v;
     }
 
     #[wasm_bindgen(getter, js_name = nmsRadius)]
     pub fn nms_radius(&self) -> u32 {
-        self.inner.nms_radius
+        self.cell.borrow().nms_radius
     }
     #[wasm_bindgen(setter, js_name = nmsRadius)]
     pub fn set_nms_radius(&mut self, v: u32) {
-        self.inner.nms_radius = v;
+        self.cell.borrow_mut().nms_radius = v;
     }
 
     #[wasm_bindgen(getter, js_name = minClusterSize)]
     pub fn min_cluster_size(&self) -> u32 {
-        self.inner.min_cluster_size
+        self.cell.borrow().min_cluster_size
     }
     #[wasm_bindgen(setter, js_name = minClusterSize)]
     pub fn set_min_cluster_size(&mut self, v: u32) {
-        self.inner.min_cluster_size = v;
+        self.cell.borrow_mut().min_cluster_size = v;
     }
 }
 
@@ -701,11 +734,11 @@ impl Default for RadonDetectorParams {
 }
 
 impl RadonDetectorParams {
-    pub(crate) fn inner(&self) -> RsRadonDetectorParams {
-        self.inner
+    pub(crate) fn share_cell(&self) -> Cell<RsRadonDetectorParams> {
+        Rc::clone(&self.cell)
     }
-    pub(crate) fn from_inner(inner: RsRadonDetectorParams) -> Self {
-        Self { inner }
+    pub(crate) fn from_cell(cell: Cell<RsRadonDetectorParams>) -> Self {
+        Self { cell }
     }
 }
 
@@ -713,11 +746,10 @@ impl RadonDetectorParams {
 // UpscaleConfig
 // ---------------------------------------------------------------------------
 
-/// Pre-pipeline integer upscaling configuration.
 #[wasm_bindgen]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct UpscaleConfig {
-    inner: RsUpscaleConfig,
+    cell: Cell<RsUpscaleConfig>,
 }
 
 #[wasm_bindgen]
@@ -725,40 +757,40 @@ impl UpscaleConfig {
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
         Self {
-            inner: RsUpscaleConfig::default(),
+            cell: cell(RsUpscaleConfig::default()),
         }
     }
 
     /// Factory for a disabled upscale (default).
     pub fn disabled() -> Self {
         Self {
-            inner: RsUpscaleConfig::disabled(),
+            cell: cell(RsUpscaleConfig::disabled()),
         }
     }
 
     /// Factory for a fixed integer-factor upscale (2, 3, or 4).
     pub fn fixed(factor: u32) -> Self {
         Self {
-            inner: RsUpscaleConfig::fixed(factor),
+            cell: cell(RsUpscaleConfig::fixed(factor)),
         }
     }
 
     #[wasm_bindgen(getter)]
     pub fn mode(&self) -> UpscaleMode {
-        self.inner.mode.into()
+        self.cell.borrow().mode.into()
     }
     #[wasm_bindgen(setter)]
     pub fn set_mode(&mut self, v: UpscaleMode) {
-        self.inner.mode = v.into();
+        self.cell.borrow_mut().mode = v.into();
     }
 
     #[wasm_bindgen(getter)]
     pub fn factor(&self) -> u32 {
-        self.inner.factor
+        self.cell.borrow().factor
     }
     #[wasm_bindgen(setter)]
     pub fn set_factor(&mut self, v: u32) {
-        self.inner.factor = v;
+        self.cell.borrow_mut().factor = v;
     }
 }
 
@@ -769,11 +801,11 @@ impl Default for UpscaleConfig {
 }
 
 impl UpscaleConfig {
-    pub(crate) fn inner(&self) -> RsUpscaleConfig {
-        self.inner
+    pub(crate) fn share_cell(&self) -> Cell<RsUpscaleConfig> {
+        Rc::clone(&self.cell)
     }
-    pub(crate) fn from_inner(inner: RsUpscaleConfig) -> Self {
-        Self { inner }
+    pub(crate) fn from_cell(cell: Cell<RsUpscaleConfig>) -> Self {
+        Self { cell }
     }
 }
 
@@ -786,7 +818,68 @@ impl UpscaleConfig {
 #[wasm_bindgen]
 #[derive(Clone, Debug)]
 pub struct ChessConfig {
-    inner: RsChessConfig,
+    // Scalar fields are stored in their own single-purpose cells.
+    // The wrapper-level `Clone` returns a shallow copy that shares
+    // these cells with the original — `cfg.refiner.kind = X` after
+    // `let cfg2 = cfg.clone()` (Rust-side) would also affect cfg2,
+    // intentionally, because the cells are shared.
+    detector_mode: Cell<RsDetectorMode>,
+    descriptor_mode: Cell<RsDescriptorMode>,
+    threshold_mode: Cell<RsThresholdMode>,
+    threshold_value: Cell<f32>,
+    nms_radius: Cell<u32>,
+    min_cluster_size: Cell<u32>,
+    pyramid_levels: Cell<u8>,
+    pyramid_min_size: Cell<usize>,
+    refinement_radius: Cell<u32>,
+    merge_radius: Cell<f32>,
+    refiner: RefinerConfig,
+    upscale: Cell<RsUpscaleConfig>,
+    radon_detector: Cell<RsRadonDetectorParams>,
+}
+
+impl ChessConfig {
+    pub(crate) fn from_value_pub(value: RsChessConfig) -> Self {
+        Self::from_value(value)
+    }
+
+    fn from_value(value: RsChessConfig) -> Self {
+        Self {
+            detector_mode: cell(value.detector_mode),
+            descriptor_mode: cell(value.descriptor_mode),
+            threshold_mode: cell(value.threshold_mode),
+            threshold_value: cell(value.threshold_value),
+            nms_radius: cell(value.nms_radius),
+            min_cluster_size: cell(value.min_cluster_size),
+            pyramid_levels: cell(value.pyramid_levels),
+            pyramid_min_size: cell(value.pyramid_min_size),
+            refinement_radius: cell(value.refinement_radius),
+            merge_radius: cell(value.merge_radius),
+            refiner: RefinerConfig::from_value(value.refiner),
+            upscale: cell(value.upscale),
+            radon_detector: cell(value.radon_detector),
+        }
+    }
+
+    /// Snapshot the current state into the Rust facade
+    /// `ChessConfig` for hand-off to the detector.
+    pub(crate) fn snapshot(&self) -> RsChessConfig {
+        let mut cfg = RsChessConfig::default();
+        cfg.detector_mode = *self.detector_mode.borrow();
+        cfg.descriptor_mode = *self.descriptor_mode.borrow();
+        cfg.threshold_mode = *self.threshold_mode.borrow();
+        cfg.threshold_value = *self.threshold_value.borrow();
+        cfg.nms_radius = *self.nms_radius.borrow();
+        cfg.min_cluster_size = *self.min_cluster_size.borrow();
+        cfg.pyramid_levels = *self.pyramid_levels.borrow();
+        cfg.pyramid_min_size = *self.pyramid_min_size.borrow();
+        cfg.refinement_radius = *self.refinement_radius.borrow();
+        cfg.merge_radius = *self.merge_radius.borrow();
+        cfg.refiner = self.refiner.snapshot();
+        cfg.upscale = *self.upscale.borrow();
+        cfg.radon_detector = *self.radon_detector.borrow();
+        cfg
+    }
 }
 
 #[wasm_bindgen]
@@ -795,159 +888,151 @@ impl ChessConfig {
     /// (single-scale, absolute threshold = 0.0).
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
-        Self {
-            inner: RsChessConfig::default(),
-        }
+        Self::from_value(RsChessConfig::default())
     }
 
     /// Single-scale preset (alias for [`Self::new`]).
     #[wasm_bindgen(js_name = singleScale)]
     pub fn single_scale() -> Self {
-        Self {
-            inner: RsChessConfig::single_scale(),
-        }
+        Self::from_value(RsChessConfig::single_scale())
     }
 
     /// Recommended 3-level multiscale preset.
     pub fn multiscale() -> Self {
-        Self {
-            inner: RsChessConfig::multiscale(),
-        }
+        Self::from_value(RsChessConfig::multiscale())
     }
 
     /// Whole-image Radon detector preset.
     pub fn radon() -> Self {
-        Self {
-            inner: RsChessConfig::radon(),
-        }
+        Self::from_value(RsChessConfig::radon())
     }
 
-    // ---- Top-level fields ----
+    // ---- Top-level scalar fields ----
+    // Note: `Default for ChessConfig` is provided below outside the
+    // `#[wasm_bindgen]` impl so that wasm-bindgen doesn't try to
+    // expose it as a JS method.
 
     #[wasm_bindgen(getter, js_name = detectorMode)]
     pub fn detector_mode(&self) -> DetectorMode {
-        self.inner.detector_mode.into()
+        (*self.detector_mode.borrow()).into()
     }
     #[wasm_bindgen(setter, js_name = detectorMode)]
     pub fn set_detector_mode(&mut self, v: DetectorMode) {
-        self.inner.detector_mode = v.into();
+        *self.detector_mode.borrow_mut() = v.into();
     }
 
     #[wasm_bindgen(getter, js_name = descriptorMode)]
     pub fn descriptor_mode(&self) -> DescriptorMode {
-        self.inner.descriptor_mode.into()
+        (*self.descriptor_mode.borrow()).into()
     }
     #[wasm_bindgen(setter, js_name = descriptorMode)]
     pub fn set_descriptor_mode(&mut self, v: DescriptorMode) {
-        self.inner.descriptor_mode = v.into();
+        *self.descriptor_mode.borrow_mut() = v.into();
     }
 
     #[wasm_bindgen(getter, js_name = thresholdMode)]
     pub fn threshold_mode(&self) -> ThresholdMode {
-        self.inner.threshold_mode.into()
+        (*self.threshold_mode.borrow()).into()
     }
     #[wasm_bindgen(setter, js_name = thresholdMode)]
     pub fn set_threshold_mode(&mut self, v: ThresholdMode) {
-        self.inner.threshold_mode = v.into();
+        *self.threshold_mode.borrow_mut() = v.into();
     }
 
     #[wasm_bindgen(getter, js_name = thresholdValue)]
     pub fn threshold_value(&self) -> f32 {
-        self.inner.threshold_value
+        *self.threshold_value.borrow()
     }
     #[wasm_bindgen(setter, js_name = thresholdValue)]
     pub fn set_threshold_value(&mut self, v: f32) {
-        self.inner.threshold_value = v;
+        *self.threshold_value.borrow_mut() = v;
     }
 
     #[wasm_bindgen(getter, js_name = nmsRadius)]
     pub fn nms_radius(&self) -> u32 {
-        self.inner.nms_radius
+        *self.nms_radius.borrow()
     }
     #[wasm_bindgen(setter, js_name = nmsRadius)]
     pub fn set_nms_radius(&mut self, v: u32) {
-        self.inner.nms_radius = v;
+        *self.nms_radius.borrow_mut() = v;
     }
 
     #[wasm_bindgen(getter, js_name = minClusterSize)]
     pub fn min_cluster_size(&self) -> u32 {
-        self.inner.min_cluster_size
+        *self.min_cluster_size.borrow()
     }
     #[wasm_bindgen(setter, js_name = minClusterSize)]
     pub fn set_min_cluster_size(&mut self, v: u32) {
-        self.inner.min_cluster_size = v;
-    }
-
-    /// Returns a *clone* of the refiner config. Mutate it and
-    /// assign it back via [`Self::set_refiner`] to persist the edit
-    /// (see crate-level docs for the round-trip idiom).
-    #[wasm_bindgen(getter)]
-    pub fn refiner(&self) -> RefinerConfig {
-        RefinerConfig::from_inner(self.inner.refiner.clone())
-    }
-    #[wasm_bindgen(setter)]
-    pub fn set_refiner(&mut self, v: &RefinerConfig) {
-        self.inner.refiner = v.inner();
+        *self.min_cluster_size.borrow_mut() = v;
     }
 
     #[wasm_bindgen(getter, js_name = pyramidLevels)]
     pub fn pyramid_levels(&self) -> u8 {
-        self.inner.pyramid_levels
+        *self.pyramid_levels.borrow()
     }
     #[wasm_bindgen(setter, js_name = pyramidLevels)]
     pub fn set_pyramid_levels(&mut self, v: u8) {
-        self.inner.pyramid_levels = v;
+        *self.pyramid_levels.borrow_mut() = v;
     }
 
     #[wasm_bindgen(getter, js_name = pyramidMinSize)]
     pub fn pyramid_min_size(&self) -> u32 {
-        self.inner.pyramid_min_size as u32
+        *self.pyramid_min_size.borrow() as u32
     }
     #[wasm_bindgen(setter, js_name = pyramidMinSize)]
     pub fn set_pyramid_min_size(&mut self, v: u32) {
-        self.inner.pyramid_min_size = v as usize;
+        *self.pyramid_min_size.borrow_mut() = v as usize;
     }
 
     #[wasm_bindgen(getter, js_name = refinementRadius)]
     pub fn refinement_radius(&self) -> u32 {
-        self.inner.refinement_radius
+        *self.refinement_radius.borrow()
     }
     #[wasm_bindgen(setter, js_name = refinementRadius)]
     pub fn set_refinement_radius(&mut self, v: u32) {
-        self.inner.refinement_radius = v;
+        *self.refinement_radius.borrow_mut() = v;
     }
 
     #[wasm_bindgen(getter, js_name = mergeRadius)]
     pub fn merge_radius(&self) -> f32 {
-        self.inner.merge_radius
+        *self.merge_radius.borrow()
     }
     #[wasm_bindgen(setter, js_name = mergeRadius)]
     pub fn set_merge_radius(&mut self, v: f32) {
-        self.inner.merge_radius = v;
+        *self.merge_radius.borrow_mut() = v;
     }
 
-    /// Returns a *clone* of the upscale config. Mutate it and
-    /// assign it back via [`Self::set_upscale`] to persist the edit
-    /// (see crate-level docs for the round-trip idiom).
+    // ---- Nested wrappers (live views via shared cells) ----
+
+    #[wasm_bindgen(getter)]
+    pub fn refiner(&self) -> RefinerConfig {
+        self.refiner.clone()
+    }
+    #[wasm_bindgen(setter)]
+    pub fn set_refiner(&mut self, v: &RefinerConfig) {
+        // Reseat all five cells so future `cfg.refiner.*` calls
+        // observe `v`'s state. JS code that already held the
+        // previous `cfg.refiner` keeps observing the previous cells
+        // — matches natural JS attribute-replacement semantics.
+        self.refiner = v.clone();
+    }
+
     #[wasm_bindgen(getter)]
     pub fn upscale(&self) -> UpscaleConfig {
-        UpscaleConfig::from_inner(self.inner.upscale)
+        UpscaleConfig::from_cell(Rc::clone(&self.upscale))
     }
     #[wasm_bindgen(setter)]
     pub fn set_upscale(&mut self, v: &UpscaleConfig) {
-        self.inner.upscale = v.inner();
+        self.upscale = v.share_cell();
     }
 
-    /// Returns a *clone* of the Radon detector params. Mutate them
-    /// and assign back via [`Self::set_radon_detector`] to persist
-    /// the edit (see crate-level docs for the round-trip idiom).
     #[wasm_bindgen(getter, js_name = radonDetector)]
     pub fn radon_detector(&self) -> RadonDetectorParams {
-        RadonDetectorParams::from_inner(self.inner.radon_detector)
+        RadonDetectorParams::from_cell(Rc::clone(&self.radon_detector))
     }
     #[wasm_bindgen(setter, js_name = radonDetector)]
     pub fn set_radon_detector(&mut self, v: &RadonDetectorParams) {
-        self.inner.radon_detector = v.inner();
+        self.radon_detector = v.share_cell();
     }
 }
 
@@ -957,15 +1042,102 @@ impl Default for ChessConfig {
     }
 }
 
-impl ChessConfig {
-    /// Borrow the underlying Rust config (used by the detector).
-    pub(crate) fn inner(&self) -> &RsChessConfig {
-        &self.inner
+#[cfg(test)]
+mod tests {
+    //! Native Rust tests of the shared-cell semantics. These run on
+    //! `cargo test -p chess-corners-wasm` (host target) and don't
+    //! need a JS runner. wasm-bindgen-test would be needed to
+    //! exercise the JS-facing getter/setter mangling, but the cell
+    //! plumbing is what matters for the live-edit guarantee and is
+    //! identical on host and on wasm32.
+
+    use super::*;
+    use chess_corners::{
+        DetectorMode as RsDetectorMode, RefinementMethod as RsRefinementMethod,
+    };
+
+    #[test]
+    fn nested_edits_propagate_through_chess_config() {
+        let cfg = ChessConfig::new();
+        // `cfg.refiner` returns a wrapper sharing cells with `cfg`.
+        let mut r = cfg.refiner();
+        r.set_kind(RefinementMethod::Forstner);
+
+        // The mutation must be visible on a fresh getter call.
+        assert_eq!(
+            cfg.snapshot().refiner.kind,
+            RsRefinementMethod::Forstner,
+            "cfg.refiner.kind = X must propagate without round-trip"
+        );
+
+        // Per-variant edits also propagate.
+        let mut f = cfg.refiner().forstner();
+        f.set_max_offset(2.5);
+        assert_eq!(cfg.snapshot().refiner.forstner.max_offset, 2.5);
     }
-    /// Mutable borrow used by the legacy setter shortcuts on
-    /// `ChessDetector` (e.g. `set_threshold` mirroring into both
-    /// ChESS and Radon paths).
-    pub(crate) fn inner_mut(&mut self) -> &mut RsChessConfig {
-        &mut self.inner
+
+    #[test]
+    fn radon_detector_edits_propagate() {
+        let cfg = ChessConfig::new();
+        let mut radon = cfg.radon_detector();
+        radon.set_ray_radius(7);
+        radon.set_image_upsample(2);
+        let snap = cfg.snapshot();
+        assert_eq!(snap.radon_detector.ray_radius, 7);
+        assert_eq!(snap.radon_detector.image_upsample, 2);
+    }
+
+    #[test]
+    fn upscale_edits_propagate() {
+        let cfg = ChessConfig::new();
+        let mut up = cfg.upscale();
+        up.set_factor(3);
+        up.set_mode(UpscaleMode::Fixed);
+        let snap = cfg.snapshot();
+        assert_eq!(snap.upscale.factor, 3);
+        assert_eq!(snap.upscale.mode, RsUpscaleMode::Fixed);
+    }
+
+    #[test]
+    fn assigning_nested_wrapper_reseats_cells() {
+        let mut cfg = ChessConfig::new();
+        // Build a freestanding refiner with a custom kind.
+        let mut new_refiner = RefinerConfig::new();
+        new_refiner.set_kind(RefinementMethod::SaddlePoint);
+        new_refiner.forstner().set_max_offset(3.5);
+
+        cfg.set_refiner(&new_refiner);
+
+        // Reseating must take effect for future getter calls.
+        let snap = cfg.snapshot();
+        assert_eq!(snap.refiner.kind, RsRefinementMethod::SaddlePoint);
+        assert_eq!(snap.refiner.forstner.max_offset, 3.5);
+
+        // And `cfg.refiner.*` is now backed by `new_refiner`'s cells:
+        // mutating `new_refiner` afterwards must propagate.
+        new_refiner.forstner().set_max_offset(4.5);
+        assert_eq!(cfg.snapshot().refiner.forstner.max_offset, 4.5);
+    }
+
+    #[test]
+    fn top_level_scalar_setters_match_facade_defaults() {
+        let mut cfg = ChessConfig::new();
+        cfg.set_detector_mode(DetectorMode::Radon);
+        cfg.set_threshold_value(0.42);
+        let snap = cfg.snapshot();
+        assert_eq!(snap.detector_mode, RsDetectorMode::Radon);
+        assert!((snap.threshold_value - 0.42).abs() < 1e-6);
+    }
+
+    #[test]
+    fn snapshot_returns_independent_state() {
+        // After capturing a snapshot, further edits to the wrapper
+        // must NOT leak into the snapshot — the snapshot's
+        // `RsChessConfig` value is plain Rust (no Rc).
+        let mut cfg = ChessConfig::new();
+        cfg.set_threshold_value(0.1);
+        let snap = cfg.snapshot();
+        cfg.set_threshold_value(0.9);
+        assert!((snap.threshold_value - 0.1).abs() < 1e-6);
     }
 }

--- a/crates/chess-corners-wasm/src/config.rs
+++ b/crates/chess-corners-wasm/src/config.rs
@@ -504,6 +504,12 @@ impl RadonPeakConfig {
 // ---------------------------------------------------------------------------
 
 /// Subpixel refiner selection plus per-variant parameters.
+///
+/// **Round-trip idiom for nested edits.** Per-variant getters
+/// (`centerOfMass`, `forstner`, `saddlePoint`, `radonPeak`) return a
+/// fresh clone of the inner config. Editing the returned object does
+/// not flow back; assign through the parent setter instead. See the
+/// crate-level docs for the full pattern.
 #[wasm_bindgen]
 #[derive(Clone, Debug)]
 pub struct RefinerConfig {
@@ -528,6 +534,9 @@ impl RefinerConfig {
         self.inner.kind = v.into();
     }
 
+    /// Returns a *clone* of the per-variant config. Mutate it and
+    /// assign it back via [`Self::set_center_of_mass`] to persist
+    /// the edit (see crate-level docs for the round-trip idiom).
     #[wasm_bindgen(getter, js_name = centerOfMass)]
     pub fn center_of_mass(&self) -> CenterOfMassConfig {
         CenterOfMassConfig::from_inner(self.inner.center_of_mass)
@@ -537,6 +546,9 @@ impl RefinerConfig {
         self.inner.center_of_mass = v.inner();
     }
 
+    /// Returns a *clone* of the Förstner refiner config. Mutate it
+    /// and assign it back via [`Self::set_forstner`] to persist the
+    /// edit (see crate-level docs for the round-trip idiom).
     #[wasm_bindgen(getter)]
     pub fn forstner(&self) -> ForstnerConfig {
         ForstnerConfig::from_inner(self.inner.forstner)
@@ -546,6 +558,10 @@ impl RefinerConfig {
         self.inner.forstner = v.inner();
     }
 
+    /// Returns a *clone* of the saddle-point refiner config. Mutate
+    /// it and assign it back via [`Self::set_saddle_point`] to
+    /// persist the edit (see crate-level docs for the round-trip
+    /// idiom).
     #[wasm_bindgen(getter, js_name = saddlePoint)]
     pub fn saddle_point(&self) -> SaddlePointConfig {
         SaddlePointConfig::from_inner(self.inner.saddle_point)
@@ -555,6 +571,9 @@ impl RefinerConfig {
         self.inner.saddle_point = v.inner();
     }
 
+    /// Returns a *clone* of the Radon-peak refiner config. Mutate it
+    /// and assign it back via [`Self::set_radon_peak`] to persist
+    /// the edit (see crate-level docs for the round-trip idiom).
     #[wasm_bindgen(getter, js_name = radonPeak)]
     pub fn radon_peak(&self) -> RadonPeakConfig {
         RadonPeakConfig::from_inner(self.inner.radon_peak)
@@ -859,6 +878,9 @@ impl ChessConfig {
         self.inner.min_cluster_size = v;
     }
 
+    /// Returns a *clone* of the refiner config. Mutate it and
+    /// assign it back via [`Self::set_refiner`] to persist the edit
+    /// (see crate-level docs for the round-trip idiom).
     #[wasm_bindgen(getter)]
     pub fn refiner(&self) -> RefinerConfig {
         RefinerConfig::from_inner(self.inner.refiner.clone())
@@ -904,6 +926,9 @@ impl ChessConfig {
         self.inner.merge_radius = v;
     }
 
+    /// Returns a *clone* of the upscale config. Mutate it and
+    /// assign it back via [`Self::set_upscale`] to persist the edit
+    /// (see crate-level docs for the round-trip idiom).
     #[wasm_bindgen(getter)]
     pub fn upscale(&self) -> UpscaleConfig {
         UpscaleConfig::from_inner(self.inner.upscale)
@@ -913,6 +938,9 @@ impl ChessConfig {
         self.inner.upscale = v.inner();
     }
 
+    /// Returns a *clone* of the Radon detector params. Mutate them
+    /// and assign back via [`Self::set_radon_detector`] to persist
+    /// the edit (see crate-level docs for the round-trip idiom).
     #[wasm_bindgen(getter, js_name = radonDetector)]
     pub fn radon_detector(&self) -> RadonDetectorParams {
         RadonDetectorParams::from_inner(self.inner.radon_detector)

--- a/crates/chess-corners-wasm/src/config.rs
+++ b/crates/chess-corners-wasm/src/config.rs
@@ -1,0 +1,943 @@
+//! Typed `#[wasm_bindgen]` wrappers around `chess-corners` config
+//! structs.
+//!
+//! Each wrapper stores its inner Rust value by value and exposes
+//! per-field getters/setters with TypeScript-friendly types. The
+//! wrappers do not own any state beyond the inner value — passing a
+//! wrapper into `ChessDetector::with_config` clones the inner Rust
+//! struct.
+//!
+//! Why a wrapper layer at all? The Rust source-of-truth structs live
+//! in `chess-corners` / `chess-corners-core` and must not depend on
+//! `wasm-bindgen` (per the workspace dependency rule in `AGENTS.md`).
+//! These wrappers add the JS-facing attribute layer in the WASM
+//! crate only.
+
+use chess_corners::{
+    CenterOfMassConfig as RsCenterOfMassConfig, ChessConfig as RsChessConfig,
+    DescriptorMode as RsDescriptorMode, DetectorMode as RsDetectorMode,
+    ForstnerConfig as RsForstnerConfig, PeakFitMode as RsPeakFitMode,
+    RadonDetectorParams as RsRadonDetectorParams, RadonPeakConfig as RsRadonPeakConfig,
+    RefinementMethod as RsRefinementMethod, RefinerConfig as RsRefinerConfig,
+    SaddlePointConfig as RsSaddlePointConfig, ThresholdMode as RsThresholdMode,
+    UpscaleConfig as RsUpscaleConfig, UpscaleMode as RsUpscaleMode,
+};
+use wasm_bindgen::prelude::*;
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+/// Detector kernel selection. Mirrors [`chess_corners::DetectorMode`].
+#[wasm_bindgen]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DetectorMode {
+    Canonical = 0,
+    Broad = 1,
+    Radon = 2,
+}
+
+impl From<DetectorMode> for RsDetectorMode {
+    fn from(v: DetectorMode) -> Self {
+        match v {
+            DetectorMode::Canonical => RsDetectorMode::Canonical,
+            DetectorMode::Broad => RsDetectorMode::Broad,
+            DetectorMode::Radon => RsDetectorMode::Radon,
+        }
+    }
+}
+
+impl From<RsDetectorMode> for DetectorMode {
+    fn from(v: RsDetectorMode) -> Self {
+        match v {
+            RsDetectorMode::Canonical => DetectorMode::Canonical,
+            RsDetectorMode::Broad => DetectorMode::Broad,
+            RsDetectorMode::Radon => DetectorMode::Radon,
+        }
+    }
+}
+
+/// Descriptor sampling override. Mirrors [`chess_corners::DescriptorMode`].
+#[wasm_bindgen]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DescriptorMode {
+    FollowDetector = 0,
+    Canonical = 1,
+    Broad = 2,
+}
+
+impl From<DescriptorMode> for RsDescriptorMode {
+    fn from(v: DescriptorMode) -> Self {
+        match v {
+            DescriptorMode::FollowDetector => RsDescriptorMode::FollowDetector,
+            DescriptorMode::Canonical => RsDescriptorMode::Canonical,
+            DescriptorMode::Broad => RsDescriptorMode::Broad,
+        }
+    }
+}
+
+impl From<RsDescriptorMode> for DescriptorMode {
+    fn from(v: RsDescriptorMode) -> Self {
+        match v {
+            RsDescriptorMode::FollowDetector => DescriptorMode::FollowDetector,
+            RsDescriptorMode::Canonical => DescriptorMode::Canonical,
+            RsDescriptorMode::Broad => DescriptorMode::Broad,
+        }
+    }
+}
+
+/// Threshold interpretation. Mirrors [`chess_corners::ThresholdMode`].
+#[wasm_bindgen]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ThresholdMode {
+    Relative = 0,
+    Absolute = 1,
+}
+
+impl From<ThresholdMode> for RsThresholdMode {
+    fn from(v: ThresholdMode) -> Self {
+        match v {
+            ThresholdMode::Relative => RsThresholdMode::Relative,
+            ThresholdMode::Absolute => RsThresholdMode::Absolute,
+        }
+    }
+}
+
+impl From<RsThresholdMode> for ThresholdMode {
+    fn from(v: RsThresholdMode) -> Self {
+        match v {
+            RsThresholdMode::Relative => ThresholdMode::Relative,
+            RsThresholdMode::Absolute => ThresholdMode::Absolute,
+        }
+    }
+}
+
+/// Subpixel refinement algorithm. Mirrors
+/// [`chess_corners::RefinementMethod`].
+#[wasm_bindgen]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RefinementMethod {
+    CenterOfMass = 0,
+    Forstner = 1,
+    SaddlePoint = 2,
+    RadonPeak = 3,
+}
+
+impl From<RefinementMethod> for RsRefinementMethod {
+    fn from(v: RefinementMethod) -> Self {
+        match v {
+            RefinementMethod::CenterOfMass => RsRefinementMethod::CenterOfMass,
+            RefinementMethod::Forstner => RsRefinementMethod::Forstner,
+            RefinementMethod::SaddlePoint => RsRefinementMethod::SaddlePoint,
+            RefinementMethod::RadonPeak => RsRefinementMethod::RadonPeak,
+        }
+    }
+}
+
+impl From<RsRefinementMethod> for RefinementMethod {
+    fn from(v: RsRefinementMethod) -> Self {
+        match v {
+            RsRefinementMethod::CenterOfMass => RefinementMethod::CenterOfMass,
+            RsRefinementMethod::Forstner => RefinementMethod::Forstner,
+            RsRefinementMethod::SaddlePoint => RefinementMethod::SaddlePoint,
+            RsRefinementMethod::RadonPeak => RefinementMethod::RadonPeak,
+        }
+    }
+}
+
+/// Subpixel peak-fit mode (Radon). Mirrors
+/// [`chess_corners::PeakFitMode`].
+#[wasm_bindgen]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PeakFitMode {
+    Parabolic = 0,
+    Gaussian = 1,
+}
+
+impl From<PeakFitMode> for RsPeakFitMode {
+    fn from(v: PeakFitMode) -> Self {
+        match v {
+            PeakFitMode::Parabolic => RsPeakFitMode::Parabolic,
+            PeakFitMode::Gaussian => RsPeakFitMode::Gaussian,
+        }
+    }
+}
+
+impl From<RsPeakFitMode> for PeakFitMode {
+    fn from(v: RsPeakFitMode) -> Self {
+        match v {
+            RsPeakFitMode::Parabolic => PeakFitMode::Parabolic,
+            RsPeakFitMode::Gaussian => PeakFitMode::Gaussian,
+            // The core enum is `#[non_exhaustive]`. New variants
+            // would land here; map them to `Gaussian` (the default)
+            // until the wrapper learns the new variant.
+            _ => PeakFitMode::Gaussian,
+        }
+    }
+}
+
+/// Pre-pipeline upscale mode. Mirrors [`chess_corners::UpscaleMode`].
+#[wasm_bindgen]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UpscaleMode {
+    Disabled = 0,
+    Fixed = 1,
+}
+
+impl From<UpscaleMode> for RsUpscaleMode {
+    fn from(v: UpscaleMode) -> Self {
+        match v {
+            UpscaleMode::Disabled => RsUpscaleMode::Disabled,
+            UpscaleMode::Fixed => RsUpscaleMode::Fixed,
+        }
+    }
+}
+
+impl From<RsUpscaleMode> for UpscaleMode {
+    fn from(v: RsUpscaleMode) -> Self {
+        match v {
+            RsUpscaleMode::Disabled => UpscaleMode::Disabled,
+            RsUpscaleMode::Fixed => UpscaleMode::Fixed,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CenterOfMassConfig
+// ---------------------------------------------------------------------------
+
+/// Center-of-mass refiner configuration.
+#[wasm_bindgen]
+#[derive(Clone, Copy, Debug)]
+pub struct CenterOfMassConfig {
+    inner: RsCenterOfMassConfig,
+}
+
+#[wasm_bindgen]
+impl CenterOfMassConfig {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self {
+            inner: RsCenterOfMassConfig::default(),
+        }
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn radius(&self) -> i32 {
+        self.inner.radius
+    }
+    #[wasm_bindgen(setter)]
+    pub fn set_radius(&mut self, v: i32) {
+        self.inner.radius = v;
+    }
+}
+
+impl Default for CenterOfMassConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CenterOfMassConfig {
+    pub(crate) fn inner(&self) -> RsCenterOfMassConfig {
+        self.inner
+    }
+    pub(crate) fn from_inner(inner: RsCenterOfMassConfig) -> Self {
+        Self { inner }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ForstnerConfig
+// ---------------------------------------------------------------------------
+
+/// Förstner gradient-based refiner configuration.
+#[wasm_bindgen]
+#[derive(Clone, Copy, Debug)]
+pub struct ForstnerConfig {
+    inner: RsForstnerConfig,
+}
+
+#[wasm_bindgen]
+impl ForstnerConfig {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self {
+            inner: RsForstnerConfig::default(),
+        }
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn radius(&self) -> i32 {
+        self.inner.radius
+    }
+    #[wasm_bindgen(setter)]
+    pub fn set_radius(&mut self, v: i32) {
+        self.inner.radius = v;
+    }
+
+    #[wasm_bindgen(getter, js_name = minTrace)]
+    pub fn min_trace(&self) -> f32 {
+        self.inner.min_trace
+    }
+    #[wasm_bindgen(setter, js_name = minTrace)]
+    pub fn set_min_trace(&mut self, v: f32) {
+        self.inner.min_trace = v;
+    }
+
+    #[wasm_bindgen(getter, js_name = minDet)]
+    pub fn min_det(&self) -> f32 {
+        self.inner.min_det
+    }
+    #[wasm_bindgen(setter, js_name = minDet)]
+    pub fn set_min_det(&mut self, v: f32) {
+        self.inner.min_det = v;
+    }
+
+    #[wasm_bindgen(getter, js_name = maxConditionNumber)]
+    pub fn max_condition_number(&self) -> f32 {
+        self.inner.max_condition_number
+    }
+    #[wasm_bindgen(setter, js_name = maxConditionNumber)]
+    pub fn set_max_condition_number(&mut self, v: f32) {
+        self.inner.max_condition_number = v;
+    }
+
+    #[wasm_bindgen(getter, js_name = maxOffset)]
+    pub fn max_offset(&self) -> f32 {
+        self.inner.max_offset
+    }
+    #[wasm_bindgen(setter, js_name = maxOffset)]
+    pub fn set_max_offset(&mut self, v: f32) {
+        self.inner.max_offset = v;
+    }
+}
+
+impl Default for ForstnerConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ForstnerConfig {
+    pub(crate) fn inner(&self) -> RsForstnerConfig {
+        self.inner
+    }
+    pub(crate) fn from_inner(inner: RsForstnerConfig) -> Self {
+        Self { inner }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SaddlePointConfig
+// ---------------------------------------------------------------------------
+
+/// Quadratic saddle-point refiner configuration.
+#[wasm_bindgen]
+#[derive(Clone, Copy, Debug)]
+pub struct SaddlePointConfig {
+    inner: RsSaddlePointConfig,
+}
+
+#[wasm_bindgen]
+impl SaddlePointConfig {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self {
+            inner: RsSaddlePointConfig::default(),
+        }
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn radius(&self) -> i32 {
+        self.inner.radius
+    }
+    #[wasm_bindgen(setter)]
+    pub fn set_radius(&mut self, v: i32) {
+        self.inner.radius = v;
+    }
+
+    #[wasm_bindgen(getter, js_name = detMargin)]
+    pub fn det_margin(&self) -> f32 {
+        self.inner.det_margin
+    }
+    #[wasm_bindgen(setter, js_name = detMargin)]
+    pub fn set_det_margin(&mut self, v: f32) {
+        self.inner.det_margin = v;
+    }
+
+    #[wasm_bindgen(getter, js_name = maxOffset)]
+    pub fn max_offset(&self) -> f32 {
+        self.inner.max_offset
+    }
+    #[wasm_bindgen(setter, js_name = maxOffset)]
+    pub fn set_max_offset(&mut self, v: f32) {
+        self.inner.max_offset = v;
+    }
+
+    #[wasm_bindgen(getter, js_name = minAbsDet)]
+    pub fn min_abs_det(&self) -> f32 {
+        self.inner.min_abs_det
+    }
+    #[wasm_bindgen(setter, js_name = minAbsDet)]
+    pub fn set_min_abs_det(&mut self, v: f32) {
+        self.inner.min_abs_det = v;
+    }
+}
+
+impl Default for SaddlePointConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SaddlePointConfig {
+    pub(crate) fn inner(&self) -> RsSaddlePointConfig {
+        self.inner
+    }
+    pub(crate) fn from_inner(inner: RsSaddlePointConfig) -> Self {
+        Self { inner }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RadonPeakConfig
+// ---------------------------------------------------------------------------
+
+/// Radon-peak refiner configuration.
+#[wasm_bindgen]
+#[derive(Clone, Copy, Debug)]
+pub struct RadonPeakConfig {
+    inner: RsRadonPeakConfig,
+}
+
+#[wasm_bindgen]
+impl RadonPeakConfig {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self {
+            inner: RsRadonPeakConfig::default(),
+        }
+    }
+
+    #[wasm_bindgen(getter, js_name = rayRadius)]
+    pub fn ray_radius(&self) -> u32 {
+        self.inner.ray_radius
+    }
+    #[wasm_bindgen(setter, js_name = rayRadius)]
+    pub fn set_ray_radius(&mut self, v: u32) {
+        self.inner.ray_radius = v;
+    }
+
+    #[wasm_bindgen(getter, js_name = patchRadius)]
+    pub fn patch_radius(&self) -> u32 {
+        self.inner.patch_radius
+    }
+    #[wasm_bindgen(setter, js_name = patchRadius)]
+    pub fn set_patch_radius(&mut self, v: u32) {
+        self.inner.patch_radius = v;
+    }
+
+    #[wasm_bindgen(getter, js_name = imageUpsample)]
+    pub fn image_upsample(&self) -> u32 {
+        self.inner.image_upsample
+    }
+    #[wasm_bindgen(setter, js_name = imageUpsample)]
+    pub fn set_image_upsample(&mut self, v: u32) {
+        self.inner.image_upsample = v;
+    }
+
+    #[wasm_bindgen(getter, js_name = responseBlurRadius)]
+    pub fn response_blur_radius(&self) -> u32 {
+        self.inner.response_blur_radius
+    }
+    #[wasm_bindgen(setter, js_name = responseBlurRadius)]
+    pub fn set_response_blur_radius(&mut self, v: u32) {
+        self.inner.response_blur_radius = v;
+    }
+
+    #[wasm_bindgen(getter, js_name = peakFit)]
+    pub fn peak_fit(&self) -> PeakFitMode {
+        self.inner.peak_fit.into()
+    }
+    #[wasm_bindgen(setter, js_name = peakFit)]
+    pub fn set_peak_fit(&mut self, v: PeakFitMode) {
+        self.inner.peak_fit = v.into();
+    }
+
+    #[wasm_bindgen(getter, js_name = minResponse)]
+    pub fn min_response(&self) -> f32 {
+        self.inner.min_response
+    }
+    #[wasm_bindgen(setter, js_name = minResponse)]
+    pub fn set_min_response(&mut self, v: f32) {
+        self.inner.min_response = v;
+    }
+
+    #[wasm_bindgen(getter, js_name = maxOffset)]
+    pub fn max_offset(&self) -> f32 {
+        self.inner.max_offset
+    }
+    #[wasm_bindgen(setter, js_name = maxOffset)]
+    pub fn set_max_offset(&mut self, v: f32) {
+        self.inner.max_offset = v;
+    }
+}
+
+impl Default for RadonPeakConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RadonPeakConfig {
+    pub(crate) fn inner(&self) -> RsRadonPeakConfig {
+        self.inner
+    }
+    pub(crate) fn from_inner(inner: RsRadonPeakConfig) -> Self {
+        Self { inner }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RefinerConfig
+// ---------------------------------------------------------------------------
+
+/// Subpixel refiner selection plus per-variant parameters.
+#[wasm_bindgen]
+#[derive(Clone, Debug)]
+pub struct RefinerConfig {
+    inner: RsRefinerConfig,
+}
+
+#[wasm_bindgen]
+impl RefinerConfig {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self {
+            inner: RsRefinerConfig::default(),
+        }
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn kind(&self) -> RefinementMethod {
+        self.inner.kind.into()
+    }
+    #[wasm_bindgen(setter)]
+    pub fn set_kind(&mut self, v: RefinementMethod) {
+        self.inner.kind = v.into();
+    }
+
+    #[wasm_bindgen(getter, js_name = centerOfMass)]
+    pub fn center_of_mass(&self) -> CenterOfMassConfig {
+        CenterOfMassConfig::from_inner(self.inner.center_of_mass)
+    }
+    #[wasm_bindgen(setter, js_name = centerOfMass)]
+    pub fn set_center_of_mass(&mut self, v: &CenterOfMassConfig) {
+        self.inner.center_of_mass = v.inner();
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn forstner(&self) -> ForstnerConfig {
+        ForstnerConfig::from_inner(self.inner.forstner)
+    }
+    #[wasm_bindgen(setter)]
+    pub fn set_forstner(&mut self, v: &ForstnerConfig) {
+        self.inner.forstner = v.inner();
+    }
+
+    #[wasm_bindgen(getter, js_name = saddlePoint)]
+    pub fn saddle_point(&self) -> SaddlePointConfig {
+        SaddlePointConfig::from_inner(self.inner.saddle_point)
+    }
+    #[wasm_bindgen(setter, js_name = saddlePoint)]
+    pub fn set_saddle_point(&mut self, v: &SaddlePointConfig) {
+        self.inner.saddle_point = v.inner();
+    }
+
+    #[wasm_bindgen(getter, js_name = radonPeak)]
+    pub fn radon_peak(&self) -> RadonPeakConfig {
+        RadonPeakConfig::from_inner(self.inner.radon_peak)
+    }
+    #[wasm_bindgen(setter, js_name = radonPeak)]
+    pub fn set_radon_peak(&mut self, v: &RadonPeakConfig) {
+        self.inner.radon_peak = v.inner();
+    }
+}
+
+impl Default for RefinerConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RefinerConfig {
+    pub(crate) fn inner(&self) -> RsRefinerConfig {
+        self.inner.clone()
+    }
+    pub(crate) fn from_inner(inner: RsRefinerConfig) -> Self {
+        Self { inner }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RadonDetectorParams
+// ---------------------------------------------------------------------------
+
+/// Whole-image Radon detector parameters.
+#[wasm_bindgen]
+#[derive(Clone, Copy, Debug)]
+pub struct RadonDetectorParams {
+    inner: RsRadonDetectorParams,
+}
+
+#[wasm_bindgen]
+impl RadonDetectorParams {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self {
+            inner: RsRadonDetectorParams::default(),
+        }
+    }
+
+    #[wasm_bindgen(getter, js_name = rayRadius)]
+    pub fn ray_radius(&self) -> u32 {
+        self.inner.ray_radius
+    }
+    #[wasm_bindgen(setter, js_name = rayRadius)]
+    pub fn set_ray_radius(&mut self, v: u32) {
+        self.inner.ray_radius = v;
+    }
+
+    #[wasm_bindgen(getter, js_name = imageUpsample)]
+    pub fn image_upsample(&self) -> u32 {
+        self.inner.image_upsample
+    }
+    #[wasm_bindgen(setter, js_name = imageUpsample)]
+    pub fn set_image_upsample(&mut self, v: u32) {
+        self.inner.image_upsample = v;
+    }
+
+    #[wasm_bindgen(getter, js_name = responseBlurRadius)]
+    pub fn response_blur_radius(&self) -> u32 {
+        self.inner.response_blur_radius
+    }
+    #[wasm_bindgen(setter, js_name = responseBlurRadius)]
+    pub fn set_response_blur_radius(&mut self, v: u32) {
+        self.inner.response_blur_radius = v;
+    }
+
+    #[wasm_bindgen(getter, js_name = peakFit)]
+    pub fn peak_fit(&self) -> PeakFitMode {
+        self.inner.peak_fit.into()
+    }
+    #[wasm_bindgen(setter, js_name = peakFit)]
+    pub fn set_peak_fit(&mut self, v: PeakFitMode) {
+        self.inner.peak_fit = v.into();
+    }
+
+    #[wasm_bindgen(getter, js_name = thresholdRel)]
+    pub fn threshold_rel(&self) -> f32 {
+        self.inner.threshold_rel
+    }
+    #[wasm_bindgen(setter, js_name = thresholdRel)]
+    pub fn set_threshold_rel(&mut self, v: f32) {
+        self.inner.threshold_rel = v;
+    }
+
+    /// Absolute response floor; `None` to clear and let the relative
+    /// threshold decide. Pass a finite number to override.
+    #[wasm_bindgen(getter, js_name = thresholdAbs)]
+    pub fn threshold_abs(&self) -> Option<f32> {
+        self.inner.threshold_abs
+    }
+    #[wasm_bindgen(setter, js_name = thresholdAbs)]
+    pub fn set_threshold_abs(&mut self, v: Option<f32>) {
+        self.inner.threshold_abs = v;
+    }
+
+    #[wasm_bindgen(getter, js_name = nmsRadius)]
+    pub fn nms_radius(&self) -> u32 {
+        self.inner.nms_radius
+    }
+    #[wasm_bindgen(setter, js_name = nmsRadius)]
+    pub fn set_nms_radius(&mut self, v: u32) {
+        self.inner.nms_radius = v;
+    }
+
+    #[wasm_bindgen(getter, js_name = minClusterSize)]
+    pub fn min_cluster_size(&self) -> u32 {
+        self.inner.min_cluster_size
+    }
+    #[wasm_bindgen(setter, js_name = minClusterSize)]
+    pub fn set_min_cluster_size(&mut self, v: u32) {
+        self.inner.min_cluster_size = v;
+    }
+}
+
+impl Default for RadonDetectorParams {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RadonDetectorParams {
+    pub(crate) fn inner(&self) -> RsRadonDetectorParams {
+        self.inner
+    }
+    pub(crate) fn from_inner(inner: RsRadonDetectorParams) -> Self {
+        Self { inner }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// UpscaleConfig
+// ---------------------------------------------------------------------------
+
+/// Pre-pipeline integer upscaling configuration.
+#[wasm_bindgen]
+#[derive(Clone, Copy, Debug)]
+pub struct UpscaleConfig {
+    inner: RsUpscaleConfig,
+}
+
+#[wasm_bindgen]
+impl UpscaleConfig {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self {
+            inner: RsUpscaleConfig::default(),
+        }
+    }
+
+    /// Factory for a disabled upscale (default).
+    pub fn disabled() -> Self {
+        Self {
+            inner: RsUpscaleConfig::disabled(),
+        }
+    }
+
+    /// Factory for a fixed integer-factor upscale (2, 3, or 4).
+    pub fn fixed(factor: u32) -> Self {
+        Self {
+            inner: RsUpscaleConfig::fixed(factor),
+        }
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn mode(&self) -> UpscaleMode {
+        self.inner.mode.into()
+    }
+    #[wasm_bindgen(setter)]
+    pub fn set_mode(&mut self, v: UpscaleMode) {
+        self.inner.mode = v.into();
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn factor(&self) -> u32 {
+        self.inner.factor
+    }
+    #[wasm_bindgen(setter)]
+    pub fn set_factor(&mut self, v: u32) {
+        self.inner.factor = v;
+    }
+}
+
+impl Default for UpscaleConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl UpscaleConfig {
+    pub(crate) fn inner(&self) -> RsUpscaleConfig {
+        self.inner
+    }
+    pub(crate) fn from_inner(inner: RsUpscaleConfig) -> Self {
+        Self { inner }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ChessConfig
+// ---------------------------------------------------------------------------
+
+/// High-level detector configuration. Mirrors
+/// [`chess_corners::ChessConfig`].
+#[wasm_bindgen]
+#[derive(Clone, Debug)]
+pub struct ChessConfig {
+    inner: RsChessConfig,
+}
+
+#[wasm_bindgen]
+impl ChessConfig {
+    /// Construct a `ChessConfig` with library defaults
+    /// (single-scale, absolute threshold = 0.0).
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self {
+            inner: RsChessConfig::default(),
+        }
+    }
+
+    /// Single-scale preset (alias for [`Self::new`]).
+    #[wasm_bindgen(js_name = singleScale)]
+    pub fn single_scale() -> Self {
+        Self {
+            inner: RsChessConfig::single_scale(),
+        }
+    }
+
+    /// Recommended 3-level multiscale preset.
+    pub fn multiscale() -> Self {
+        Self {
+            inner: RsChessConfig::multiscale(),
+        }
+    }
+
+    /// Whole-image Radon detector preset.
+    pub fn radon() -> Self {
+        Self {
+            inner: RsChessConfig::radon(),
+        }
+    }
+
+    // ---- Top-level fields ----
+
+    #[wasm_bindgen(getter, js_name = detectorMode)]
+    pub fn detector_mode(&self) -> DetectorMode {
+        self.inner.detector_mode.into()
+    }
+    #[wasm_bindgen(setter, js_name = detectorMode)]
+    pub fn set_detector_mode(&mut self, v: DetectorMode) {
+        self.inner.detector_mode = v.into();
+    }
+
+    #[wasm_bindgen(getter, js_name = descriptorMode)]
+    pub fn descriptor_mode(&self) -> DescriptorMode {
+        self.inner.descriptor_mode.into()
+    }
+    #[wasm_bindgen(setter, js_name = descriptorMode)]
+    pub fn set_descriptor_mode(&mut self, v: DescriptorMode) {
+        self.inner.descriptor_mode = v.into();
+    }
+
+    #[wasm_bindgen(getter, js_name = thresholdMode)]
+    pub fn threshold_mode(&self) -> ThresholdMode {
+        self.inner.threshold_mode.into()
+    }
+    #[wasm_bindgen(setter, js_name = thresholdMode)]
+    pub fn set_threshold_mode(&mut self, v: ThresholdMode) {
+        self.inner.threshold_mode = v.into();
+    }
+
+    #[wasm_bindgen(getter, js_name = thresholdValue)]
+    pub fn threshold_value(&self) -> f32 {
+        self.inner.threshold_value
+    }
+    #[wasm_bindgen(setter, js_name = thresholdValue)]
+    pub fn set_threshold_value(&mut self, v: f32) {
+        self.inner.threshold_value = v;
+    }
+
+    #[wasm_bindgen(getter, js_name = nmsRadius)]
+    pub fn nms_radius(&self) -> u32 {
+        self.inner.nms_radius
+    }
+    #[wasm_bindgen(setter, js_name = nmsRadius)]
+    pub fn set_nms_radius(&mut self, v: u32) {
+        self.inner.nms_radius = v;
+    }
+
+    #[wasm_bindgen(getter, js_name = minClusterSize)]
+    pub fn min_cluster_size(&self) -> u32 {
+        self.inner.min_cluster_size
+    }
+    #[wasm_bindgen(setter, js_name = minClusterSize)]
+    pub fn set_min_cluster_size(&mut self, v: u32) {
+        self.inner.min_cluster_size = v;
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn refiner(&self) -> RefinerConfig {
+        RefinerConfig::from_inner(self.inner.refiner.clone())
+    }
+    #[wasm_bindgen(setter)]
+    pub fn set_refiner(&mut self, v: &RefinerConfig) {
+        self.inner.refiner = v.inner();
+    }
+
+    #[wasm_bindgen(getter, js_name = pyramidLevels)]
+    pub fn pyramid_levels(&self) -> u8 {
+        self.inner.pyramid_levels
+    }
+    #[wasm_bindgen(setter, js_name = pyramidLevels)]
+    pub fn set_pyramid_levels(&mut self, v: u8) {
+        self.inner.pyramid_levels = v;
+    }
+
+    #[wasm_bindgen(getter, js_name = pyramidMinSize)]
+    pub fn pyramid_min_size(&self) -> u32 {
+        self.inner.pyramid_min_size as u32
+    }
+    #[wasm_bindgen(setter, js_name = pyramidMinSize)]
+    pub fn set_pyramid_min_size(&mut self, v: u32) {
+        self.inner.pyramid_min_size = v as usize;
+    }
+
+    #[wasm_bindgen(getter, js_name = refinementRadius)]
+    pub fn refinement_radius(&self) -> u32 {
+        self.inner.refinement_radius
+    }
+    #[wasm_bindgen(setter, js_name = refinementRadius)]
+    pub fn set_refinement_radius(&mut self, v: u32) {
+        self.inner.refinement_radius = v;
+    }
+
+    #[wasm_bindgen(getter, js_name = mergeRadius)]
+    pub fn merge_radius(&self) -> f32 {
+        self.inner.merge_radius
+    }
+    #[wasm_bindgen(setter, js_name = mergeRadius)]
+    pub fn set_merge_radius(&mut self, v: f32) {
+        self.inner.merge_radius = v;
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn upscale(&self) -> UpscaleConfig {
+        UpscaleConfig::from_inner(self.inner.upscale)
+    }
+    #[wasm_bindgen(setter)]
+    pub fn set_upscale(&mut self, v: &UpscaleConfig) {
+        self.inner.upscale = v.inner();
+    }
+
+    #[wasm_bindgen(getter, js_name = radonDetector)]
+    pub fn radon_detector(&self) -> RadonDetectorParams {
+        RadonDetectorParams::from_inner(self.inner.radon_detector)
+    }
+    #[wasm_bindgen(setter, js_name = radonDetector)]
+    pub fn set_radon_detector(&mut self, v: &RadonDetectorParams) {
+        self.inner.radon_detector = v.inner();
+    }
+}
+
+impl Default for ChessConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ChessConfig {
+    /// Borrow the underlying Rust config (used by the detector).
+    pub(crate) fn inner(&self) -> &RsChessConfig {
+        &self.inner
+    }
+    /// Mutable borrow used by the legacy setter shortcuts on
+    /// `ChessDetector` (e.g. `set_threshold` mirroring into both
+    /// ChESS and Radon paths).
+    pub(crate) fn inner_mut(&mut self) -> &mut RsChessConfig {
+        &mut self.inner
+    }
+}

--- a/crates/chess-corners-wasm/src/lib.rs
+++ b/crates/chess-corners-wasm/src/lib.rs
@@ -15,33 +15,19 @@
 //! Both paths edit the same underlying Rust struct, so they can be
 //! mixed at will.
 //!
-//! # Editing nested typed configs (round-trip idiom)
+//! # Editing nested typed configs
 //!
-//! `wasm-bindgen` getters that return a struct hand JS an opaque
-//! handle to a *fresh clone* of the nested value, not a live view.
-//! That means writing the chained form
-//!
-//! ```ignore
-//! cfg.refiner.kind = RefinementMethod.RadonPeak;   // edits a temporary,
-//!                                                   // does NOT update cfg
-//! ```
-//!
-//! mutates the temporary clone and is silently lost when `cfg` is
-//! later passed to [`ChessDetector::with_config`] /
-//! [`ChessDetector::apply_config`]. To persist a nested edit, capture
-//! the getter result, mutate it, and assign it back through the
-//! parent setter:
+//! Nested edits propagate naturally — getters hand back a wrapper
+//! backed by the same shared cell as the parent, so chained mutation
+//! works without a round-trip:
 //!
 //! ```ignore
-//! const r = cfg.refiner;                  // pull a clone out
-//! r.kind = RefinementMethod.RadonPeak;    // edit the clone
-//! cfg.refiner = r;                        // write it back
+//! cfg.refiner.kind = RefinementMethod.RadonPeak;   // propagates
+//! cfg.refiner.forstner.maxOffset = 2.0;            // propagates
+//! cfg.radonDetector.rayRadius = 5;                 // propagates
 //! ```
 //!
-//! Same pattern applies to `cfg.radonDetector`, `cfg.upscale`, and
-//! `cfg.refiner.{centerOfMass, forstner, saddlePoint, radonPeak}`.
-//! Top-level scalar fields (e.g. `cfg.thresholdValue = 0.15`) work
-//! directly because the setter mutates the parent in place.
+//! See [`config`] for the cell-sharing details.
 
 pub mod config;
 
@@ -135,10 +121,10 @@ impl ChessDetector {
     /// setter-shortcut path).
     #[wasm_bindgen(js_name = withConfig)]
     pub fn with_config(config: &ChessConfig) -> Self {
-        let inner = config.inner().clone();
-        let levels = inner.pyramid_levels;
+        let snapshot = config.snapshot();
+        let levels = snapshot.pyramid_levels;
         Self {
-            config: inner,
+            config: snapshot,
             buffers: PyramidBuffers::with_capacity(levels),
             last_response: None,
             last_radon_response: None,
@@ -147,25 +133,25 @@ impl ChessDetector {
     }
 
     /// Snapshot the current configuration as a typed
-    /// [`ChessConfig`]. Mutations to the
-    /// returned object do not flow back; use [`Self::apply_config`]
-    /// to commit changes.
+    /// [`ChessConfig`]. The returned object is a snapshot — its
+    /// cells are *not* shared with the detector's live state. Use
+    /// [`Self::apply_config`] to commit edits made on the snapshot.
     #[wasm_bindgen(js_name = getConfig)]
     pub fn get_config(&self) -> ChessConfig {
         ChessConfig::from_inner_for_js(self.config.clone())
     }
 
     /// Replace the detector's configuration with the given typed
-    /// [`ChessConfig`]. Resizes pyramid
-    /// scratch buffers if `pyramid_levels` changed.
+    /// [`ChessConfig`]. Resizes pyramid scratch buffers if
+    /// `pyramid_levels` changed.
     #[wasm_bindgen(js_name = applyConfig)]
     pub fn apply_config(&mut self, config: &ChessConfig) {
-        let inner = config.inner().clone();
-        let levels = inner.pyramid_levels;
+        let snapshot = config.snapshot();
+        let levels = snapshot.pyramid_levels;
         if levels != self.config.pyramid_levels {
             self.buffers = PyramidBuffers::with_capacity(levels);
         }
-        self.config = inner;
+        self.config = snapshot;
     }
 
     // ---- Config setters ----
@@ -450,13 +436,12 @@ fn corners_to_f32_array(corners: &[chess_corners::CornerDescriptor]) -> js_sys::
     arr
 }
 
-// Helpers used by `lib.rs` to round-trip the inner config through the
-// JS-facing wrapper. Kept private to the crate.
+// Helper used by `lib.rs` to wrap a Rust facade `ChessConfig` value
+// in a fresh JS-facing wrapper. The returned wrapper owns brand-new
+// cells (not shared with the source value) — this is intentional for
+// `getConfig()` snapshot semantics.
 impl ChessConfig {
     pub(crate) fn from_inner_for_js(inner: chess_corners::ChessConfig) -> Self {
-        // Reuse the existing constructor pattern in `config.rs`.
-        let mut cfg = Self::new();
-        *cfg.inner_mut() = inner;
-        cfg
+        Self::from_value_pub(inner)
     }
 }

--- a/crates/chess-corners-wasm/src/lib.rs
+++ b/crates/chess-corners-wasm/src/lib.rs
@@ -1,10 +1,36 @@
+//! WebAssembly bindings for the ChESS / Radon corner detector.
+//!
+//! Two ways to drive the detector from JS:
+//!
+//! 1. **Setter shortcuts** — `new ChessDetector()` then
+//!    `det.set_threshold(...)` / `det.set_pyramid_levels(...)` /
+//!    `det.set_detector_mode("radon")` etc. Existing demo code uses
+//!    this path. Backwards-compatible.
+//! 2. **Typed `ChessConfig`** — construct the typed
+//!    [`ChessConfig`] (with nested `RefinerConfig`,
+//!    `RadonDetectorParams`, `UpscaleConfig`, …), then pass it to
+//!    [`ChessDetector::with_config`]. Exposes every public Rust
+//!    facade field with type-safe getters/setters.
+//!
+//! Both paths edit the same underlying Rust struct, so they can be
+//! mixed at will.
+
+pub mod config;
+
 use chess_corners::{
-    radon_heatmap_u8, ChessConfig, DetectorMode, PyramidBuffers, RefinementMethod, ThresholdMode,
-    UpscaleConfig,
+    radon_heatmap_u8, ChessConfig as RsChessConfig, DetectorMode as RsDetectorMode, PyramidBuffers,
+    RefinementMethod as RsRefinementMethod, ThresholdMode as RsThresholdMode,
+    UpscaleConfig as RsUpscaleConfig,
 };
 use chess_corners_core::response::chess_response_u8;
 use chess_corners_core::ResponseMap;
 use wasm_bindgen::prelude::*;
+
+pub use crate::config::{
+    CenterOfMassConfig, ChessConfig, DescriptorMode, DetectorMode, ForstnerConfig, PeakFitMode,
+    RadonDetectorParams, RadonPeakConfig, RefinementMethod, RefinerConfig, SaddlePointConfig,
+    ThresholdMode, UpscaleConfig, UpscaleMode,
+};
 
 /// Convert RGBA pixels to grayscale using BT.601 luminance weights.
 fn rgba_to_gray(rgba: &[u8], width: u32, height: u32) -> Vec<u8> {
@@ -26,7 +52,7 @@ fn rgba_to_gray(rgba: &[u8], width: u32, height: u32) -> Vec<u8> {
 /// storage.
 #[wasm_bindgen]
 pub struct ChessDetector {
-    config: ChessConfig,
+    config: RsChessConfig,
     buffers: PyramidBuffers,
     last_response: Option<ResponseMap>,
     last_radon_response: Option<ResponseMap>,
@@ -52,7 +78,7 @@ impl ChessDetector {
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
         Self {
-            config: ChessConfig::single_scale(),
+            config: RsChessConfig::single_scale(),
             buffers: PyramidBuffers::with_capacity(1),
             last_response: None,
             last_radon_response: None,
@@ -62,7 +88,7 @@ impl ChessDetector {
 
     /// Create a detector with the recommended multiscale preset.
     pub fn multiscale() -> Self {
-        let config = ChessConfig::multiscale();
+        let config = RsChessConfig::multiscale();
         let levels = config.pyramid_levels;
         Self {
             config,
@@ -71,6 +97,46 @@ impl ChessDetector {
             last_radon_response: None,
             last_radon_scale: 0,
         }
+    }
+
+    /// Create a detector seeded from a typed
+    /// [`ChessConfig`]. The full public
+    /// config surface — refiner subconfigs, Radon params, descriptor
+    /// mode, coarse-to-fine radii, upscale — is reachable through
+    /// the typed object (see module docs for the alternative
+    /// setter-shortcut path).
+    #[wasm_bindgen(js_name = withConfig)]
+    pub fn with_config(config: &ChessConfig) -> Self {
+        let inner = config.inner().clone();
+        let levels = inner.pyramid_levels;
+        Self {
+            config: inner,
+            buffers: PyramidBuffers::with_capacity(levels),
+            last_response: None,
+            last_radon_response: None,
+        }
+    }
+
+    /// Snapshot the current configuration as a typed
+    /// [`ChessConfig`]. Mutations to the
+    /// returned object do not flow back; use [`Self::apply_config`]
+    /// to commit changes.
+    #[wasm_bindgen(js_name = getConfig)]
+    pub fn get_config(&self) -> ChessConfig {
+        ChessConfig::from_inner_for_js(self.config.clone())
+    }
+
+    /// Replace the detector's configuration with the given typed
+    /// [`ChessConfig`]. Resizes pyramid
+    /// scratch buffers if `pyramid_levels` changed.
+    #[wasm_bindgen(js_name = applyConfig)]
+    pub fn apply_config(&mut self, config: &ChessConfig) {
+        let inner = config.inner().clone();
+        let levels = inner.pyramid_levels;
+        if levels != self.config.pyramid_levels {
+            self.buffers = PyramidBuffers::with_capacity(levels);
+        }
+        self.config = inner;
     }
 
     // ---- Config setters ----
@@ -90,7 +156,7 @@ impl ChessDetector {
     /// `radon_detector.threshold_rel` and clears any absolute override
     /// on `threshold_abs` so the relative value wins.
     pub fn set_threshold(&mut self, rel: f32) {
-        self.config.threshold_mode = ThresholdMode::Relative;
+        self.config.threshold_mode = RsThresholdMode::Relative;
         self.config.threshold_value = rel;
         self.config.radon_detector.threshold_rel = rel;
         self.config.radon_detector.threshold_abs = None;
@@ -114,9 +180,9 @@ impl ChessDetector {
     /// Toggle the large r=10 ring (default: r=5).
     pub fn set_broad_mode(&mut self, v: bool) {
         self.config.detector_mode = if v {
-            DetectorMode::Broad
+            RsDetectorMode::Broad
         } else {
-            DetectorMode::Canonical
+            RsDetectorMode::Canonical
         };
     }
 
@@ -128,9 +194,9 @@ impl ChessDetector {
     /// switches because those setters mirror into both detectors.
     pub fn set_detector_mode(&mut self, name: &str) -> Result<(), JsValue> {
         self.config.detector_mode = match name {
-            "canonical" => DetectorMode::Canonical,
-            "broad" => DetectorMode::Broad,
-            "radon" => DetectorMode::Radon,
+            "canonical" => RsDetectorMode::Canonical,
+            "broad" => RsDetectorMode::Broad,
+            "radon" => RsDetectorMode::Radon,
             _ => {
                 return Err(JsValue::from_str(
                     "unknown detector_mode: use canonical, broad, or radon",
@@ -172,8 +238,8 @@ impl ChessDetector {
     /// in input-image pixel space; callers do not need to rescale.
     pub fn set_upscale_factor(&mut self, factor: u32) -> Result<(), JsValue> {
         self.config.upscale = match factor {
-            0 | 1 => UpscaleConfig::disabled(),
-            2..=4 => UpscaleConfig::fixed(factor),
+            0 | 1 => RsUpscaleConfig::disabled(),
+            2..=4 => RsUpscaleConfig::fixed(factor),
             other => {
                 return Err(JsValue::from_str(&format!(
                     "unsupported upscale factor {other} (expected 0, 1, 2, 3, or 4)",
@@ -188,10 +254,10 @@ impl ChessDetector {
     pub fn set_refiner(&mut self, name: &str) -> Result<(), JsValue> {
         self.config.refiner.kind =
             match name {
-                "center_of_mass" => RefinementMethod::CenterOfMass,
-                "forstner" => RefinementMethod::Forstner,
-                "saddle_point" => RefinementMethod::SaddlePoint,
-                "radon_peak" => RefinementMethod::RadonPeak,
+                "center_of_mass" => RsRefinementMethod::CenterOfMass,
+                "forstner" => RsRefinementMethod::Forstner,
+                "saddle_point" => RsRefinementMethod::SaddlePoint,
+                "radon_peak" => RsRefinementMethod::RadonPeak,
                 _ => return Err(JsValue::from_str(
                     "unknown refiner: use center_of_mass, forstner, saddle_point, or radon_peak",
                 )),
@@ -353,4 +419,15 @@ fn corners_to_f32_array(corners: &[chess_corners::CornerDescriptor]) -> js_sys::
     let arr = js_sys::Float32Array::new_with_length(flat.len() as u32);
     arr.copy_from(&flat);
     arr
+}
+
+// Helpers used by `lib.rs` to round-trip the inner config through the
+// JS-facing wrapper. Kept private to the crate.
+impl ChessConfig {
+    pub(crate) fn from_inner_for_js(inner: chess_corners::ChessConfig) -> Self {
+        // Reuse the existing constructor pattern in `config.rs`.
+        let mut cfg = Self::new();
+        *cfg.inner_mut() = inner;
+        cfg
+    }
 }

--- a/crates/chess-corners-wasm/src/lib.rs
+++ b/crates/chess-corners-wasm/src/lib.rs
@@ -14,6 +14,34 @@
 //!
 //! Both paths edit the same underlying Rust struct, so they can be
 //! mixed at will.
+//!
+//! # Editing nested typed configs (round-trip idiom)
+//!
+//! `wasm-bindgen` getters that return a struct hand JS an opaque
+//! handle to a *fresh clone* of the nested value, not a live view.
+//! That means writing the chained form
+//!
+//! ```ignore
+//! cfg.refiner.kind = RefinementMethod.RadonPeak;   // edits a temporary,
+//!                                                   // does NOT update cfg
+//! ```
+//!
+//! mutates the temporary clone and is silently lost when `cfg` is
+//! later passed to [`ChessDetector::with_config`] /
+//! [`ChessDetector::apply_config`]. To persist a nested edit, capture
+//! the getter result, mutate it, and assign it back through the
+//! parent setter:
+//!
+//! ```ignore
+//! const r = cfg.refiner;                  // pull a clone out
+//! r.kind = RefinementMethod.RadonPeak;    // edit the clone
+//! cfg.refiner = r;                        // write it back
+//! ```
+//!
+//! Same pattern applies to `cfg.radonDetector`, `cfg.upscale`, and
+//! `cfg.refiner.{centerOfMass, forstner, saddlePoint, radonPeak}`.
+//! Top-level scalar fields (e.g. `cfg.thresholdValue = 0.15`) work
+//! directly because the setter mutates the parent in place.
 
 pub mod config;
 
@@ -114,6 +142,7 @@ impl ChessDetector {
             buffers: PyramidBuffers::with_capacity(levels),
             last_response: None,
             last_radon_response: None,
+            last_radon_scale: 0,
         }
     }
 


### PR DESCRIPTION
## Summary

- Close the WASM-vs-workspace tunability gap (audited in [the planning doc](https://github.com/VitalyVorobyev/chess-corners-rs/blob/main/AGENTS.md)) by exposing the entire public \`chess-corners\` config surface as native \`#[wasm_bindgen]\` classes with camelCase getters/setters and proper TypeScript types.
- Refiner subconfigs, Radon detector parameters, descriptor mode, coarse-to-fine radii — all previously locked to defaults from JS — are now reachable through typed objects.
- The legacy \`set_*\` shortcut methods on \`ChessDetector\` continue to work and edit the same underlying configuration, so the two styles can be mixed at will (no breaking changes).

## ⚠️ Stacked on #45

This PR depends on #45 (Radon heatmap public API). Base is set to \`feat/radon-heatmap-public-api\` so reviewers see only the typed-config delta. After #45 merges, GitHub will re-target this PR to \`main\` automatically.

## What's new

### New JS/TS classes (\`crates/chess-corners-wasm/src/config.rs\`)

- \`ChessConfig\` — top-level config; \`singleScale\`, \`multiscale\`, \`radon\` static factories.
- \`RefinerConfig\`, \`CenterOfMassConfig\`, \`ForstnerConfig\`, \`SaddlePointConfig\`, \`RadonPeakConfig\` — per-variant refiner parameters.
- \`RadonDetectorParams\` — full Radon tuning (rayRadius, imageUpsample, peakFit, thresholdRel/Abs, nmsRadius, minClusterSize, responseBlurRadius).
- \`UpscaleConfig\` — pre-pipeline upscale; replaces the factor-only \`set_upscale_factor\` setter for callers wanting the full mode/factor object.
- Enums: \`DetectorMode\`, \`DescriptorMode\`, \`ThresholdMode\`, \`RefinementMethod\`, \`PeakFitMode\`, \`UpscaleMode\` — ordinal-encoded for stable JS/TS interop.

### New \`ChessDetector\` methods

- \`ChessDetector.withConfig(cfg)\` — construct from a typed \`ChessConfig\`.
- \`det.getConfig()\` — snapshot the current config.
- \`det.applyConfig(cfg)\` — replace the config (resizes pyramid buffers if \`pyramidLevels\` changed).

### Layering

The Rust source-of-truth structs in \`chess-corners\` / \`chess-corners-core\` are unchanged. Only wrapper classes are added, in the WASM crate, preserving the AGENTS.md rule that core crates do not depend on \`wasm-bindgen\` / \`pyo3\`.

## Deferred / explicit follow-ups

- **Python typed FFI.** Python already has typed dataclasses on the public side, but the FFI boundary still serializes through JSON. Replacing the dataclasses with PyO3 \`#[pyclass]\` wrappers is a sizeable refactor (touches \`__init__.py\`, every test, and any downstream consumer relying on \`to_dict\`/\`to_json\`); scoped as a separate PR.
- **ML refiner in WASM.** Would require cross-compiling \`chess-corners-ml\` (\`tract-onnx\`) to \`wasm32-unknown-unknown\` — non-trivial R&D; deferred.

## Test plan

- [x] \`cargo fmt --all --check\`
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\`
- [x] \`cargo test --workspace --all-features\` (all green incl. doctests)
- [x] \`cargo doc --workspace --no-deps --all-features\` warning-free (intra-doc links resolve)
- [x] \`mdbook build book\`
- [x] \`pytest crates/chess-corners-py/python_tests\` 12/12
- [x] \`wasm-pack build crates/chess-corners-wasm --target web\` — generated \`.d.ts\` exports all wrapper classes, enums, and the new \`withConfig\`/\`getConfig\`/\`applyConfig\` methods
- [ ] Manually exercise the typed-config path in a TypeScript playground; confirm autocompletion on \`cfg.radonDetector.rayRadius\` etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)