### PR TITLE
fix(ci): select installed Rust toolchains explicitly

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Select stable Rust toolchain
+        run: rustup override set stable
+
       - name: Cache cargo artifacts
         uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Cache cargo artifacts
         uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
 
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,6 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         toolchain: [stable, nightly]
 
-    # Override rust-toolchain.toml (which pins nightly for local dev) so the
-    # matrix cells actually test the intended channel. Without this, the
-    # toolchain file silently shadows the matrix entry — and on macos-latest
-    # (Homebrew rustup with self-update disabled) the resulting auto-install
-    # of the missing nightly toolchain fails with a `rustup-init` usage error.
-    env:
-      RUSTUP_TOOLCHAIN: ${{ matrix.toolchain }}
-
     steps:
       - uses: actions/checkout@v6
 
@@ -35,19 +27,15 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
+          components: ${{ matrix.toolchain == 'stable' && 'rustfmt' || 'clippy' }}
+
+      - name: Select matrix Rust toolchain
+        run: rustup override set ${{ matrix.toolchain }}
 
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-
-      - name: Add rustfmt (stable runs the fmt gate)
-        if: matrix.toolchain == 'stable'
-        run: rustup component add rustfmt
-
-      - name: Add clippy (nightly runs the clippy gate)
-        if: matrix.toolchain == 'nightly'
-        run: rustup component add clippy
 
       - name: check documented crate versions
         if: matrix.os == 'ubuntu-latest' && matrix.toolchain == 'stable'
@@ -102,11 +90,6 @@ jobs:
     name: MSRV check (Rust 1.88)
     runs-on: ubuntu-latest
 
-    # Override rust-toolchain.toml so the MSRV gate actually exercises Rust
-    # 1.88 instead of falling back to the nightly channel pinned for local dev.
-    env:
-      RUSTUP_TOOLCHAIN: "1.88"
-
     steps:
       - uses: actions/checkout@v6
 
@@ -114,6 +97,9 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.88"
+
+      - name: Select MSRV Rust toolchain
+        run: rustup override set 1.88
 
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
@@ -160,6 +146,9 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Select stable Rust toolchain
+        run: rustup override set stable
 
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
         with:
+          cache-bin: false
           cache-on-failure: true
 
       - name: check documented crate versions
@@ -104,6 +105,7 @@ jobs:
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
         with:
+          cache-bin: false
           cache-on-failure: true
 
       - name: Build (no-default-features + rayon)
@@ -153,6 +155,7 @@ jobs:
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
         with:
+          cache-bin: false
           cache-on-failure: true
 
       - name: Install wasm-pack

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
         with:
+          cache-bin: false
           cache-on-failure: true
 
       - name: Build documentation

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,9 +29,10 @@ jobs:
         uses: actions/configure-pages@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rust-docs
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Select nightly Rust toolchain
+        run: rustup override set nightly
 
       - name: Install mdBook
         uses: taiki-e/install-action@v2

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -22,6 +22,9 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - name: Select stable Rust toolchain
+        run: rustup override set stable
+
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
 
@@ -106,6 +109,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
+
+      - name: Select stable Rust toolchain
+        run: rustup override set stable
 
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq

--- a/.github/workflows/release-npm-deprecate.yml
+++ b/.github/workflows/release-npm-deprecate.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Select stable Rust toolchain
+        run: rustup override set stable
+
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Select stable Rust toolchain
+        run: rustup override set stable
+
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 


### PR DESCRIPTION
## Summary
- install the CI matrix Rust toolchain with its required component up front
- select the installed toolchain with `rustup override set` instead of relying on job-wide `RUSTUP_TOOLCHAIN`
- disable `Swatinem/rust-cache`'s `cache-bin` restore so stale `~/.cargo/bin` shims cannot replace the freshly installed `cargo`
- apply explicit toolchain selection to docs, audit, crates.io, and npm release workflows so `rust-toolchain.toml` cannot trigger hidden toolchain behavior

## Verification
- parsed all workflow YAML files with Ruby `YAML.load_file`
- ran `git diff --check`
- observed PR CI run 25855314883 pass the previously failing `clippy` step on macOS nightly